### PR TITLE
Update Governance Action standards and guidelines

### DIFF
--- a/src/gov-action-contracts/README.md
+++ b/src/gov-action-contracts/README.md
@@ -6,7 +6,7 @@ A Governance Action Contract (GAC) is a contract used by governance to execute a
 This subdirectory includes a number of Governance Action Contracts Arbitrum Governance may at some point opt to use. Note that many of these contracts — e.g., `PauseInboxAction` — would only ever be used in a time-sensitive emergency; they are included only so that the community is prepared to act swiftly if and when such an emergency arises. 
 
 
-### Governance Action Contract Standards and Guidelines
+## Governance Action Contract Standards and Guidelines
 
 The following standards/guidelines for GACs are meant to maximize the work (engineering, auditing, etc.) that can be performed prior to the point at which an upgrade is planned, and minimize the potential for human error when/if an upgrade is planned for execution. They also tend towards simplicity and consistency:
 
@@ -18,3 +18,13 @@ The following standards/guidelines for GACs are meant to maximize the work (engi
 3. GACs should not access or modify their own state (since they are called via `delegatecall`). Any state variables on the contract should thus be `immutable` or `constant` (as these are not stored in state).
 4. GACs contract names should be suffixed with `Action`.
 5. GACs should revert on failure.
+
+## Using libraries
+The GAC author should also consider writing the GAC `perform` function logic in a Solidity library, then calling the library from the GAC. When doing this, library authors should make the library functions internal, as an external function will trigger another delegate call. 
+The advantages of using a library are:
+* Libaries can called by other GACs, enabling GAC logic to be re-used.
+* Solidity libraries restrict access to storage to the function argument list (except when using assembly), this helps to ensure the GAC is not acessing storage (see 3. above)
+
+The disadvantage of this approach is that calling multiple libraries from a GAC may lead to a confusing and complicated call path. 
+
+Judging this tradeoff is up to the author, but the focus should always be on readiblity and auditability of the code.

--- a/src/gov-action-contracts/README.md
+++ b/src/gov-action-contracts/README.md
@@ -11,11 +11,10 @@ This subdirectory includes a number of Governance Action Contracts Arbitrum Gove
 The following standards/guidelines for GACs are meant to maximize the work (engineering, auditing, etc.) that can be performed prior to the point at which an upgrade is planned, and minimize the potential for human error when/if an upgrade is planned for execution. They also tend towards simplicity and consistency:
 
 1. A GAC should have only one external function, and it should be named `perform`. 
-1. `perform` should accept as few parameters as possible, only accepting parameters where absolutely necessary. 
+2. `perform` should accept as few parameters as possible, only accepting parameters where absolutely necessary. 
     Examples:
     - Instead of `perform` accepting a boolean parameter, create two distinct Upgrade Contracts, one which implements the `true` condition and one which implements the `false` condition.
     - Instead of `perform` accepting the contract address of a core protocol contract on (say) either Arbitrum One or Arbitrum Nova, deploy two GACs, which get access to the appropriate contract address via constructor params.
-1. GACs should not access or modify their own state (since they are called via `delegatecall`). Any state variables on the contract should thus be `immutable` or `constant` (as these are not stored in state).
-1. GACs contract names should be suffixed with `Action`.
-1. GACs should revert on failure.
-1. A GAC who's perform function does more than simply a single-line external call should use a library which implements its logic. Action libraries should only have internal functions. This patterns enables the possibility to compose actions, and also gives further assurance that no local state is accessed. 
+3. GACs should not access or modify their own state (since they are called via `delegatecall`). Any state variables on the contract should thus be `immutable` or `constant` (as these are not stored in state).
+4. GACs contract names should be suffixed with `Action`.
+5. GACs should revert on failure.


### PR DESCRIPTION
This PR removes the 6th guideline that suggests using libraries for anything that is more than a one-liner