### PR TITLE
security council cross-chain updater for elections, adding, removal [draft / experimental]

### DIFF
--- a/src/security-council-mgmt/L1SecurityCouncilUpdateRouter.sol
+++ b/src/security-council-mgmt/L1SecurityCouncilUpdateRouter.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import "../L1ArbitrumMessenger.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "./interfaces/ISecurityCouncilUpgradeExectutor.sol";
+import "@arbitrum/nitro-contracts/src/bridge/IInbox.sol";
+
+interface IInboxSubmissionFee {
+    function calculateRetryableSubmissionFee(uint256 dataLength, uint256 baseFee)
+        external
+        view
+        returns (uint256);
+}
+
+contract L1SecurityCouncilUpdateRouter is L1ArbitrumMessenger, Initializable, OwnableUpgradeable {
+    struct L2ChainToUpdate {
+        address inbox;
+        address securityCouncilUpgradeExecutor;
+        uint256 chainID;
+    }
+
+    address public governanceChainInbox;
+    address public securityCouncilManager;
+    address public l1SecurityCouncilUpgradeExecutor;
+
+    L2ChainToUpdate[] public l2ChainsToUpdateArr;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        address _governanceChainInbox,
+        address _l1SecurityCouncilUpgradeExecutor,
+        address _securityCouncilManager,
+        L2ChainToUpdate[] memory _initiall2ChainsToUpdateArr
+    ) external initializer {
+        governanceChainInbox = _governanceChainInbox;
+        securityCouncilManager = securityCouncilManager;
+        l1SecurityCouncilUpgradeExecutor = _l1SecurityCouncilUpgradeExecutor;
+        for (uint256 i = 0; i < _initiall2ChainsToUpdateArr.length; i++) {
+            _addL2ChainToUpdate(_initiall2ChainsToUpdateArr[i]);
+        }
+    }
+
+    modifier onlyFromSecurityCouncilManager() {
+        address govChainBridge = address(getBridge(governanceChainInbox));
+        require(msg.sender == govChainBridge, "L1SecurityCouncilUpdateRouter: not from bridge");
+
+        address l2ToL1Sender = super.getL2ToL1Sender(governanceChainInbox);
+        require(
+            l2ToL1Sender == securityCouncilManager,
+            "L1SecurityCouncilUpdateRouter: not from SecurityCouncilManager"
+        );
+        _;
+    }
+
+    function handleAddMember(address _member) external onlyFromSecurityCouncilManager {
+        ISecurityCouncilUpgradeExectutor(l1SecurityCouncilUpgradeExecutor).addMember(_member);
+
+        bytes memory l2CallData =
+            abi.encodeWithSelector(ISecurityCouncilUpgradeExectutor.addMember.selector, _member);
+        sendToAllL2s(l2CallData);
+    }
+
+    function handleRemoveMember(address _member) external onlyFromSecurityCouncilManager {
+        ISecurityCouncilUpgradeExectutor(l1SecurityCouncilUpgradeExecutor).removeMember(_member);
+
+        bytes memory l2CallData =
+            abi.encodeWithSelector(ISecurityCouncilUpgradeExectutor.removeMember.selector, _member);
+        sendToAllL2s(l2CallData);
+    }
+
+    function handleUpdateMembers(address[] memory _membersToAdd, address[] memory _membersToRemove)
+        external
+        onlyFromSecurityCouncilManager
+    {
+        ISecurityCouncilUpgradeExectutor(l1SecurityCouncilUpgradeExecutor).updateMembers(
+            _membersToAdd, _membersToRemove
+        );
+
+        bytes memory l2CallData = abi.encodeWithSelector(
+            ISecurityCouncilUpgradeExectutor.updateMembers.selector, _membersToAdd, _membersToRemove
+        );
+        sendToAllL2s(l2CallData);
+    }
+
+    function sendToAllL2s(bytes memory l2CallData) internal {
+        for (uint256 i = 0; i < l2ChainsToUpdateArr.length; i++) {
+            L2ChainToUpdate memory l2ChainToUpdate = l2ChainsToUpdateArr[i];
+            uint256 submissionCost = IInboxSubmissionFee(l2ChainToUpdate.inbox)
+                .calculateRetryableSubmissionFee(l2CallData.length, block.basefee);
+
+            sendTxToL2CustomRefund(
+                l2ChainToUpdate.inbox,
+                l2ChainToUpdate.securityCouncilUpgradeExecutor,
+                // TODO
+                msg.sender,
+                address(this),
+                msg.value,
+                0,
+                L2GasParams({_maxSubmissionCost: submissionCost, _maxGas: 0, _gasPriceBid: 0}),
+                l2CallData
+            );
+            // sendTxToL2(l2ChainsToUpdateArr[i].inbox, l2CallData);
+        }
+    }
+
+    function addL2ChainToUpdate(L2ChainToUpdate memory l2ChainToUpdate) external onlyOwner {
+        _addL2ChainToUpdate(l2ChainToUpdate);
+    }
+
+    function _addL2ChainToUpdate(L2ChainToUpdate memory l2ChainToUpdate) internal {
+        require(l2ChainToUpdate.inbox != address(0), "L1SecurityCouncilUpdateRouter: invalid inbox");
+        require(
+            l2ChainToUpdate.securityCouncilUpgradeExecutor != address(0),
+            "L1SecurityCouncilUpdateRouter: invalid securityCouncilUpgradeExecutor"
+        );
+        require(l2ChainToUpdate.chainID != 0, "L1SecurityCouncilUpdateRouter: invalid chainID");
+        // emit event
+        l2ChainsToUpdateArr.push(l2ChainToUpdate);
+    }
+}

--- a/src/security-council-mgmt/L1SecurityCouncilUpdateRouter.sol
+++ b/src/security-council-mgmt/L1SecurityCouncilUpdateRouter.sol
@@ -41,7 +41,7 @@ contract L1SecurityCouncilUpdateRouter is L1ArbitrumMessenger, Initializable, Ow
         securityCouncilManager = securityCouncilManager;
         l1SecurityCouncilUpgradeExecutor = _l1SecurityCouncilUpgradeExecutor;
         for (uint256 i = 0; i < _initiall2ChainsToUpdateArr.length; i++) {
-            _addL2ChainToUpdate(_initiall2ChainsToUpdateArr[i]);
+            _registerNewL2Chain(_initiall2ChainsToUpdateArr[i]);
         }
     }
 
@@ -57,24 +57,9 @@ contract L1SecurityCouncilUpdateRouter is L1ArbitrumMessenger, Initializable, Ow
         _;
     }
 
-    function handleAddMember(address _member) external onlyFromSecurityCouncilManager {
-        ISecurityCouncilUpgradeExectutor(l1SecurityCouncilUpgradeExecutor).addMember(_member);
-
-        bytes memory l2CallData =
-            abi.encodeWithSelector(ISecurityCouncilUpgradeExectutor.addMember.selector, _member);
-        sendToAllL2s(l2CallData);
-    }
-
-    function handleRemoveMember(address _member) external onlyFromSecurityCouncilManager {
-        ISecurityCouncilUpgradeExectutor(l1SecurityCouncilUpgradeExecutor).removeMember(_member);
-
-        bytes memory l2CallData =
-            abi.encodeWithSelector(ISecurityCouncilUpgradeExectutor.removeMember.selector, _member);
-        sendToAllL2s(l2CallData);
-    }
-
     function handleUpdateMembers(address[] memory _membersToAdd, address[] memory _membersToRemove)
         external
+        payable
         onlyFromSecurityCouncilManager
     {
         ISecurityCouncilUpgradeExectutor(l1SecurityCouncilUpgradeExecutor).updateMembers(
@@ -84,10 +69,6 @@ contract L1SecurityCouncilUpdateRouter is L1ArbitrumMessenger, Initializable, Ow
         bytes memory l2CallData = abi.encodeWithSelector(
             ISecurityCouncilUpgradeExectutor.updateMembers.selector, _membersToAdd, _membersToRemove
         );
-        sendToAllL2s(l2CallData);
-    }
-
-    function sendToAllL2s(bytes memory l2CallData) internal {
         for (uint256 i = 0; i < l2ChainsToUpdateArr.length; i++) {
             L2ChainToUpdate memory l2ChainToUpdate = l2ChainsToUpdateArr[i];
             uint256 submissionCost = IInboxSubmissionFee(l2ChainToUpdate.inbox)
@@ -104,22 +85,21 @@ contract L1SecurityCouncilUpdateRouter is L1ArbitrumMessenger, Initializable, Ow
                 L2GasParams({_maxSubmissionCost: submissionCost, _maxGas: 0, _gasPriceBid: 0}),
                 l2CallData
             );
-            // sendTxToL2(l2ChainsToUpdateArr[i].inbox, l2CallData);
         }
     }
 
-    function addL2ChainToUpdate(L2ChainToUpdate memory l2ChainToUpdate) external onlyOwner {
-        _addL2ChainToUpdate(l2ChainToUpdate);
+    function registerNewL2Chain(L2ChainToUpdate memory l2ChainToUpdate) external onlyOwner {
+        _registerNewL2Chain(l2ChainToUpdate);
     }
 
-    function _addL2ChainToUpdate(L2ChainToUpdate memory l2ChainToUpdate) internal {
+    function _registerNewL2Chain(L2ChainToUpdate memory l2ChainToUpdate) internal {
         require(l2ChainToUpdate.inbox != address(0), "L1SecurityCouncilUpdateRouter: invalid inbox");
         require(
             l2ChainToUpdate.securityCouncilUpgradeExecutor != address(0),
             "L1SecurityCouncilUpdateRouter: invalid securityCouncilUpgradeExecutor"
         );
         require(l2ChainToUpdate.chainID != 0, "L1SecurityCouncilUpdateRouter: invalid chainID");
-        // emit event
+        //TODO emit event
         l2ChainsToUpdateArr.push(l2ChainToUpdate);
     }
 }

--- a/src/security-council-mgmt/L1SecurityCouncilUpdateRouter.sol
+++ b/src/security-council-mgmt/L1SecurityCouncilUpdateRouter.sol
@@ -92,6 +92,7 @@ contract L1SecurityCouncilUpdateRouter is
                 address(0xdead),
                 msg.value,
                 0,
+                // possibly controversial: for each of param passing, don't attempt auto-execution
                 L2GasParams({_maxSubmissionCost: submissionCost, _maxGas: 0, _gasPriceBid: 0}),
                 l2CallData
             );

--- a/src/security-council-mgmt/SecurityCouncilManager.sol
+++ b/src/security-council-mgmt/SecurityCouncilManager.sol
@@ -80,13 +80,18 @@ contract SecurityCouncilManager is Initializable, AccessControlUpgradeable {
     function _dispatchUpdateCohort(address[] memory _newMembers, address[] memory _oldMembers)
         internal
     {
-        // TODO: remove duplicates here?
+        (address[] memory newMembers, address[] memory oldMembers) =
+            SecurityCouncilMgmtUtils.removeSharedAddresses(_newMembers, _oldMembers);
         ISecurityCouncilUpgradeExectutor(
             targetContracts.govChainEmergencySecurityCouncilUpgradeExecutor
-        ).updateMembers(_newMembers, _oldMembers);
+        ).updateMembers(newMembers, oldMembers);
         ISecurityCouncilUpgradeExectutor(
             targetContracts.govChainNonEmergencySecurityCouncilUpgradeExecutor
-        ).updateMembers(_newMembers, _oldMembers);
+        ).updateMembers(newMembers, oldMembers);
+
+        bytes memory data = abi.encodeWithSelector(
+            IL1SecurityCouncilUpdateRouter.handleUpdateCohort.selector, newMembers, oldMembers
+        );
     }
 
     function addMemberToMarchCohort(address _newMember) external onlyRole(MEMBER_ADDER_ROLE) {

--- a/src/security-council-mgmt/SecurityCouncilManager.sol
+++ b/src/security-council-mgmt/SecurityCouncilManager.sol
@@ -64,7 +64,7 @@ contract SecurityCouncilManager is Initializable, AccessControlUpgradeable {
         onlyRole(ELECTION_EXECUTOR_ROLE)
     {
         require(_newCohort.length == 6, "SecurityCouncilManager: invalid cohort length");
-        // TODO: ensure no duplicates accross cohorts; enforce here and/or in nomination process?
+        // TODO: ensure no duplicates accross cohorts; this should be enforced in nomination process. If there are duplicates, this call will revert in the Gnosis safe contract
         address[] memory previousMembersCopy;
         if (_cohort == Cohort.MARCH) {
             previousMembersCopy = SecurityCouncilMgmtUtils.copyAddressArray(marchCohort);

--- a/src/security-council-mgmt/SecurityCouncilManager.sol
+++ b/src/security-council-mgmt/SecurityCouncilManager.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@arbitrum/nitro-contracts/src/precompiles/ArbSys.sol";
+import "./interfaces/ISecurityCouncilUpgradeExectutor.sol";
+import "./interfaces/IL1SecurityCouncilUpdateRouter.sol";
+import "./SecurityCouncilMgmtUtils.sol";
+
+contract SecurityCouncilManager is Initializable, AccessControlUpgradeable {
+    address[] public marchCohort;
+    address[] public septemberCohort;
+
+    bytes32 public constant COHORT_UPDATOR_ROLE = keccak256("COHORT_UPDATOR");
+    bytes32 public constant MEMBER_ADDER_ROLE = keccak256("MEMBER_ADDER");
+    bytes32 public constant MEMBER_REMOVER_ROLE = keccak256("MEMBER_REMOVER");
+
+    struct Roles {
+        address admin;
+        address cohortUpdator;
+        address memberAdder;
+        address memberRemover;
+    }
+
+    struct TargetContracts {
+        address govChainEmergencySecurityCouncilUpgradeExecutor;
+        address govChainNonEmergencySecurityCouncilUpgradeExecutor;
+        address l1SecurityCouncilUpdateRouter;
+    }
+
+    TargetContracts targetContracts;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        address[] memory _marchCohort,
+        address[] memory _septemberCohort,
+        Roles memory _roles,
+        TargetContracts memory _targetContracts
+    ) external initializer {
+        marchCohort = _marchCohort;
+        septemberCohort = _septemberCohort;
+        // TODO verify that marchcohort.concat(septemberCohort) == current SecurityCouncil
+        _setupRole(DEFAULT_ADMIN_ROLE, _roles.admin);
+        _grantRole(COHORT_UPDATOR_ROLE, _roles.cohortUpdator);
+        _grantRole(MEMBER_ADDER_ROLE, _roles.memberAdder);
+        _grantRole(MEMBER_REMOVER_ROLE, _roles.memberRemover);
+        // TODO require non zero, require code? setter
+        targetContracts = _targetContracts;
+    }
+
+    function upgdateMarchCohort(address[] memory _newMarchCohort)
+        external
+        onlyRole(COHORT_UPDATOR_ROLE)
+    {
+        require(_newMarchCohort.length == 6, "SecurityCouncilManager: invalid march cohort length");
+        address[] memory previousMembersCopy =
+            SecurityCouncilMgmtUtils.copyAddressArray(_newMarchCohort);
+        marchCohort = _newMarchCohort;
+        _dispatchUpdateCohort(_newMarchCohort, previousMembersCopy);
+    }
+
+    function upgdateSeptemberCohort(address[] memory _newSeptemberCohort)
+        external
+        onlyRole(COHORT_UPDATOR_ROLE)
+    {
+        require(
+            _newSeptemberCohort.length == 6,
+            "SecurityCouncilManager: invalid september cohort length"
+        );
+        address[] memory previousMembersCopy =
+            SecurityCouncilMgmtUtils.copyAddressArray(_newSeptemberCohort);
+        septemberCohort = _newSeptemberCohort;
+        _dispatchUpdateCohort(_newSeptemberCohort, previousMembersCopy);
+    }
+
+    function _dispatchUpdateCohort(address[] memory _newMembers, address[] memory _oldMembers)
+        internal
+    {
+        // TODO: remove duplicates here?
+        ISecurityCouncilUpgradeExectutor(
+            targetContracts.govChainEmergencySecurityCouncilUpgradeExecutor
+        ).updateMembers(_newMembers, _oldMembers);
+        ISecurityCouncilUpgradeExectutor(
+            targetContracts.govChainNonEmergencySecurityCouncilUpgradeExecutor
+        ).updateMembers(_newMembers, _oldMembers);
+    }
+
+    function addMemberToMarchCohort(address _newMember) external onlyRole(MEMBER_ADDER_ROLE) {
+        _addMemberToCohort(_newMember, marchCohort);
+    }
+
+    function addMemberToSeptemberCohort(address _newMember) external onlyRole(MEMBER_ADDER_ROLE) {
+        _addMemberToCohort(_newMember, septemberCohort);
+    }
+
+    function _addMemberToCohort(address _newMember, address[] storage _cohort) internal {
+        require(_cohort.length < 6, "SecurityCouncilManager: cohort is full");
+        _cohort.push(_newMember);
+        _dispatchAddMember(_newMember);
+    }
+
+    function _dispatchAddMember(address _newMember) internal {
+        ISecurityCouncilUpgradeExectutor(
+            targetContracts.govChainEmergencySecurityCouncilUpgradeExecutor
+        ).addMember(_newMember);
+        ISecurityCouncilUpgradeExectutor(
+            targetContracts.govChainNonEmergencySecurityCouncilUpgradeExecutor
+        ).addMember(_newMember);
+
+        bytes memory data = abi.encodeWithSelector(
+            IL1SecurityCouncilUpdateRouter.handleAddMember.selector, _newMember
+        );
+        _sendToL1Router(data);
+    }
+
+    function removeMember(address _prevMemberInLinkedList, address _member)
+        external
+        onlyRole(MEMBER_REMOVER_ROLE)
+        returns (bool)
+    {
+        if (_removeMemberFromCohort(_prevMemberInLinkedList, _member, marchCohort)) {
+            return true;
+        }
+        if (_removeMemberFromCohort(_prevMemberInLinkedList, _member, septemberCohort)) {
+            return true;
+        }
+
+        revert("SecurityCouncilManager: member not found");
+    }
+
+    function _removeMemberFromCohort(
+        address _prevMemberInLinkedList,
+        address _member,
+        address[] storage _cohort
+    ) internal returns (bool) {
+        for (uint256 i = 0; i < _cohort.length; i++) {
+            if (_member == _cohort[i]) {
+                delete _cohort[i];
+                _dispatchRemoveMember(_prevMemberInLinkedList, _member);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function _dispatchRemoveMember(address _prevMemberInLinkedList, address _member) internal {
+        ISecurityCouncilUpgradeExectutor(
+            targetContracts.govChainEmergencySecurityCouncilUpgradeExecutor
+        ).removeMember(_prevMemberInLinkedList, _member);
+        ISecurityCouncilUpgradeExectutor(
+            targetContracts.govChainNonEmergencySecurityCouncilUpgradeExecutor
+        ).removeMember(_prevMemberInLinkedList, _member);
+        bytes memory data = abi.encodeWithSelector(
+            IL1SecurityCouncilUpdateRouter.handleRemoveMember.selector,
+            _prevMemberInLinkedList,
+            _member
+        );
+        _sendToL1Router(data);
+    }
+
+    function _sendToL1Router(bytes memory callData) internal {
+        ArbSys(0x0000000000000000000000000000000000000064).sendTxToL1(
+            targetContracts.l1SecurityCouncilUpdateRouter, callData
+        );
+    }
+}

--- a/src/security-council-mgmt/SecurityCouncilManager.sol
+++ b/src/security-council-mgmt/SecurityCouncilManager.sol
@@ -92,6 +92,7 @@ contract SecurityCouncilManager is Initializable, AccessControlUpgradeable {
         bytes memory data = abi.encodeWithSelector(
             IL1SecurityCouncilUpdateRouter.handleUpdateCohort.selector, newMembers, oldMembers
         );
+        _sendToL1Router(data);
     }
 
     function addMemberToMarchCohort(address _newMember) external onlyRole(MEMBER_ADDER_ROLE) {

--- a/src/security-council-mgmt/SecurityCouncilMgmtUtils.sol
+++ b/src/security-council-mgmt/SecurityCouncilMgmtUtils.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+library SecurityCouncilMgmtUtils {
+    function copyAddressArray(address[] memory source) public pure returns (address[] memory) {
+        uint256 length = source.length;
+        address[] memory destination = new address[](length);
+
+        for (uint256 i = 0; i < length; i++) {
+            destination[i] = source[i];
+        }
+
+        return destination;
+    }
+}

--- a/src/security-council-mgmt/SecurityCouncilMgmtUtils.sol
+++ b/src/security-council-mgmt/SecurityCouncilMgmtUtils.sol
@@ -12,4 +12,33 @@ library SecurityCouncilMgmtUtils {
 
         return destination;
     }
+
+    function isInArray(address addr, address[] memory arr) internal pure returns (bool) {
+        for (uint256 i = 0; i < arr.length; i++) {
+            if (arr[i] == addr) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function removeSharedAddresses(address[] memory arr1, address[] memory arr2)
+        external
+        returns (address[] memory newArr1, address[] memory newArr2)
+    {
+        address[] memory newArr1;
+        address[] memory newArr2;
+        for (uint256 i = 0; i < arr1.length; i++) {
+            address currentAddress = arr1[i];
+            if (!isInArray(currentAddress, arr2)) {
+                newArr1[newArr1.length] = arr1[i];
+            }
+        }
+        for (uint256 i = 0; i < arr2.length; i++) {
+            address currentAddress = arr2[i];
+            if (!isInArray(currentAddress, arr1)) {
+                newArr2[newArr2.length] = arr2[i];
+            }
+        }
+    }
 }

--- a/src/security-council-mgmt/SecurityCouncilUpgradeExecutor.sol
+++ b/src/security-council-mgmt/SecurityCouncilUpgradeExecutor.sol
@@ -24,16 +24,6 @@ contract SecurityCouncilUpgradeExecutor is
         _transferOwnership(_owner);
     }
 
-    function addMember(address _member) public onlyOwner {
-        uint256 threshold = securityCouncil.getThreshold();
-        _addMember(_member, threshold);
-    }
-
-    function removeMember(address _member) public onlyOwner {
-        uint256 threshold = securityCouncil.getThreshold();
-        _removeMember(_member, threshold);
-    }
-
     function updateMembers(address[] memory _membersToAdd, address[] memory _membersToRemove)
         external
         onlyOwner
@@ -42,6 +32,7 @@ contract SecurityCouncilUpgradeExecutor is
         for (uint256 i = 0; i < _membersToRemove.length; i++) {
             address member = _membersToRemove[i];
             for (uint256 i = 0; i < _membersToAdd.length; i++) {
+                // TODO: owner check?
                 _addMember(_membersToAdd[i], threshold);
             }
 
@@ -50,6 +41,7 @@ contract SecurityCouncilUpgradeExecutor is
                 _removeMember(member, threshold);
             }
         }
+        // TODO: sanity check for threshold ?
     }
 
     function _addMember(address _member, uint256 _threshold) internal {

--- a/src/security-council-mgmt/SecurityCouncilUpgradeExecutor.sol
+++ b/src/security-council-mgmt/SecurityCouncilUpgradeExecutor.sol
@@ -28,6 +28,7 @@ contract SecurityCouncilUpgradeExecutor is
         external
         onlyOwner
     {
+        // TODO: depluplicate? 
         uint256 threshold = securityCouncil.getThreshold();
         for (uint256 i = 0; i < _membersToRemove.length; i++) {
             address member = _membersToRemove[i];

--- a/src/security-council-mgmt/SecurityCouncilUpgradeExecutor.sol
+++ b/src/security-council-mgmt/SecurityCouncilUpgradeExecutor.sol
@@ -11,9 +11,13 @@ contract SecurityCouncilUpgradeExecutor is
     Initializable,
     OwnableUpgradeable
 {
+    // gnosis safe stores owners as linked list; SENTINAL_OWNERS is the head
     address internal constant SENTINEL_OWNERS = address(0x1);
 
     IGnosisSafe public securityCouncil;
+
+    // TODO: setter?
+    uint256 public maxMembers = 12;
 
     constructor() {
         _disableInitializers();
@@ -24,34 +28,50 @@ contract SecurityCouncilUpgradeExecutor is
         _transferOwnership(_owner);
     }
 
+    /// @notice updtae gnosis safe members. We use add and remove gnosis's swapOwners method for cleansliness of handling different sized _membersToAdd & _membersToRemove arrays
     function updateMembers(address[] memory _membersToAdd, address[] memory _membersToRemove)
         external
         onlyOwner
     {
-        // TODO: depluplicate? 
+        // All update-initiating methods in SecurityCouncilManager ensure _membersToAdd and _membersToRemove have no addresses in common.
+        // TODO We could, additionally, run removeSharedAddresses for extra insurance
+
+        // always preserve current threshold
         uint256 threshold = securityCouncil.getThreshold();
-        for (uint256 i = 0; i < _membersToRemove.length; i++) {
-            address member = _membersToRemove[i];
-            for (uint256 i = 0; i < _membersToAdd.length; i++) {
-                // TODO: owner check?
+
+        // when adding and removing, we skip if the operation is redundant (instead of letting gnosis revert).
+        // This is for race conditions of adding/removing a member and the result of an election; we want the election result to still
+        // take effect if member is added/removeed before the results are finalized.
+        for (uint256 i = 0; i < _membersToAdd.length; i++) {
+            address member = _membersToAdd[i];
+            // skip, don't revert, if it's already not a member
+            if (!securityCouncil.isOwner(member)) {
                 _addMember(_membersToAdd[i], threshold);
             }
+        }
 
-            // skip, don't revert, if it's not a member
+        for (uint256 i = 0; i < _membersToRemove.length; i++) {
+            address member = _membersToRemove[i];
+            // skip, don't revert, if it's already not a member
             if (securityCouncil.isOwner(member)) {
                 _removeMember(member, threshold);
             }
         }
-        // TODO: sanity check for threshold ?
+        // sanity check: ensure that after update, total member count is below max
+        uint256 memberCount = securityCouncil.getOwners().length;
+        require(memberCount <= maxMembers, "SecurityCouncilUpgradeExecutor: too many members");
     }
 
+    // add member to multisig
     function _addMember(address _member, uint256 _threshold) internal {
         _execFromModule(
             abi.encodeWithSelector(IGnosisSafe.addOwnerWithThreshold.selector, _member, _threshold)
         );
     }
 
+    /// remove member from multisig. takes O(n) time. gnosis safe reverts if removal puts signer count below threshold
     function _removeMember(address _member, uint256 _threshold) internal {
+        // owners are stored as a linked list and removal requires the previous owner
         address[] memory owners = securityCouncil.getOwners();
         address previousOwner = SENTINEL_OWNERS;
         for (uint256 i = 0; i < owners.length; i++) {
@@ -68,6 +88,7 @@ contract SecurityCouncilUpgradeExecutor is
         );
     }
 
+    /// @notice execute provided operation via gnosis safe's trusted  execTransactionFromModule entry point
     function _execFromModule(bytes memory data) internal {
         securityCouncil.execTransactionFromModule(
             address(securityCouncil), 0, data, Enum.Operation.Call

--- a/src/security-council-mgmt/interfaces/IGnosisSafe.sol
+++ b/src/security-council-mgmt/interfaces/IGnosisSafe.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+pragma solidity ^0.8.0;
+
+abstract contract Enum {
+    enum Operation {
+        Call,
+        DelegateCall
+    }
+}
+
+interface IGnosisSafe {
+    // Functions
+    function getOwners() external view returns (address[] memory);
+    function getThreshold() external view returns (uint256);
+    function isOwner(address owner) external view returns (bool);
+    // function isModuleEnabled(address module) external view returns (bool);
+    function addOwnerWithThreshold(address owner, uint256 threshold) external;
+    function removeOwner(address prevOwner, address owner, uint256 threshold) external;
+    // function swapOwner(address prevOwner, address oldOwner, address newOwner) external;
+
+    function execTransactionFromModule(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation
+    ) external virtual returns (bool success);
+}

--- a/src/security-council-mgmt/interfaces/IL1SecurityCouncilUpdateRouter.sol
+++ b/src/security-council-mgmt/interfaces/IL1SecurityCouncilUpdateRouter.sol
@@ -1,11 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.16;
 
+struct L2ChainToUpdate {
+    address inbox;
+    address securityCouncilUpgradeExecutor;
+    uint256 chainID;
+}
+
 interface IL1SecurityCouncilUpdateRouter {
     function handleUpdateMembers(
         address[] calldata _membersToAdd,
         address[] calldata _membersToRemove
-    ) external;
-    function handleAddMember(address _member) external;
-    function handleRemoveMember(address _prevMemberInLinkedList, address _member) external;
+    ) external payable;
+    function removeL2Chain(uint256 chainID) external returns (bool);
+    function registerL2Chain(L2ChainToUpdate memory l2ChainToUpdate) external;
 }

--- a/src/security-council-mgmt/interfaces/IL1SecurityCouncilUpdateRouter.sol
+++ b/src/security-council-mgmt/interfaces/IL1SecurityCouncilUpdateRouter.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.16;
 
 interface IL1SecurityCouncilUpdateRouter {
-    function handleUpdateCohort(
+    function handleUpdateMembers(
         address[] calldata _membersToAdd,
         address[] calldata _membersToRemove
     ) external;

--- a/src/security-council-mgmt/interfaces/IL1SecurityCouncilUpdateRouter.sol
+++ b/src/security-council-mgmt/interfaces/IL1SecurityCouncilUpdateRouter.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+interface IL1SecurityCouncilUpdateRouter {
+    function handleUpdateMembers(
+        address[] calldata _membersToAdd,
+        address[] calldata _membersToRemove
+    ) external;
+    function handleAddMember(address _member) external;
+    function handleRemoveMember(address _prevMemberInLinkedList, address _member) external;
+}

--- a/src/security-council-mgmt/interfaces/IL1SecurityCouncilUpdateRouter.sol
+++ b/src/security-council-mgmt/interfaces/IL1SecurityCouncilUpdateRouter.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.16;
 
 interface IL1SecurityCouncilUpdateRouter {
-    function handleUpdateMembers(
+    function handleUpdateCohort(
         address[] calldata _membersToAdd,
         address[] calldata _membersToRemove
     ) external;

--- a/src/security-council-mgmt/interfaces/ISecurityCouncilUpgradeExectutor.sol
+++ b/src/security-council-mgmt/interfaces/ISecurityCouncilUpgradeExectutor.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+interface ISecurityCouncilUpgradeExectutor {
+    function updateMembers(address[] calldata _membersToAdd, address[] calldata _membersToRemove)
+        external;
+    function addMember(address _member) external;
+    function removeMember(address _prevMemberInLinkedList, address _member) external;
+}

--- a/src/security-council-mgmt/interfaces/ISecurityCouncilUpgradeExectutor.sol
+++ b/src/security-council-mgmt/interfaces/ISecurityCouncilUpgradeExectutor.sol
@@ -4,5 +4,4 @@ pragma solidity 0.8.16;
 interface ISecurityCouncilUpgradeExectutor {
     function updateMembers(address[] memory _membersToAdd, address[] memory _membersToRemove)
         external;
-    // TODO initialize
 }

--- a/src/security-council-mgmt/interfaces/ISecurityCouncilUpgradeExectutor.sol
+++ b/src/security-council-mgmt/interfaces/ISecurityCouncilUpgradeExectutor.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.16;
 
 interface ISecurityCouncilUpgradeExectutor {
-    function updateMembers(address[] calldata _membersToAdd, address[] calldata _membersToRemove)
+    function updateMembers(address[] memory _membersToAdd, address[] memory _membersToRemove)
         external;
     function addMember(address _member) external;
-    function removeMember(address _prevMemberInLinkedList, address _member) external;
+    function removeMember(address _member) external;
 }

--- a/src/security-council-mgmt/interfaces/ISecurityCouncilUpgradeExectutor.sol
+++ b/src/security-council-mgmt/interfaces/ISecurityCouncilUpgradeExectutor.sol
@@ -4,6 +4,5 @@ pragma solidity 0.8.16;
 interface ISecurityCouncilUpgradeExectutor {
     function updateMembers(address[] memory _membersToAdd, address[] memory _membersToRemove)
         external;
-    function addMember(address _member) external;
-    function removeMember(address _member) external;
+    // TODO initialize
 }


### PR DESCRIPTION
Step towards security council elections / adding / removal, as described in the [constitution](https://docs.arbitrum.foundation/dao-constitution).

Lacking tests and more thorough natspec comments, will wait until this is reviewed and the general architecture is discussed & agreed upon.

Each Security Council (SC) gets its own `SecurityCouncilUpgradeExecutor` contract. To activate security council management, each SC will add its `SecurityCouncilUpgradeExecutor` as a gnosis module (this is technically all that's required, i.e., no gov proposal). 

Flow:
1. A SC update (replace cohort, remove member, or add member) is initiated. Contracts for initiation aren't implemented here; everything that follows is.
2. `SecurityCouncilManager` (on gov-chain) receives update, updates the canonical `marchCohort`/ `septemberCohort` arrays accordingly, updates the 2 gov chain SCs, and sends an L2 to L1 message to `L1SecurityCouncilUpdateRouter`.
3. `L1SecurityCouncilUpdateRouter` receives the message, updates the L1 SC, and sends l1 to l2 message to each non-gov-chain L2 to update its SC (i.e., currently just Nova on mainnet).  