### PR TITLE
Modified core governor proposal creation flow [Exploratory]

### DIFF
--- a/src/CoreProposalCreator.sol
+++ b/src/CoreProposalCreator.sol
@@ -81,22 +81,22 @@ contract CoreProposalCreator is Initializable, AccessControlUpgradeable {
 
     function initialize(
         address _l1ArbitrumTimelock,
-        uint256[] memory _l2ChainIDs,
+        uint256[] memory _chainIDs,
         UpgradeContracts[] memory _upgradeContracts,
         address _admin,
         address _proposalCreator,
         uint256 _minL1TimelockDelay
     ) external initializer {
         require(
-            _l2ChainIDs.length == _upgradeContracts.length,
-            "CoreProposalCreator: _l2ChainIDs _upgradeContracts length mismatch"
+            _chainIDs.length == _upgradeContracts.length,
+            "CoreProposalCreator: _chainIDs _upgradeContracts length mismatch"
         );
         _setupRole(DEFAULT_ADMIN_ROLE, _admin);
         _grantRole(PROPOSAL_CREATOR_ROLE, _proposalCreator);
 
         l1ArbitrumTimelock = _l1ArbitrumTimelock;
-        for (uint256 i = 0; i < _l2ChainIDs.length; i++) {
-            _registerChain(_l2ChainIDs[i], _upgradeContracts[i]);
+        for (uint256 i = 0; i < _chainIDs.length; i++) {
+            _registerChain(_chainIDs[i], _upgradeContracts[i]);
         }
         _setMinL1TimelockDelay(_minL1TimelockDelay);
     }

--- a/src/CoreProposalCreator.sol
+++ b/src/CoreProposalCreator.sol
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@arbitrum/nitro-contracts/src/precompiles/ArbSys.sol";
+
+import "./UpgradeExecutor.sol";
+import "./L1ArbitrumTimelock.sol";
+
+interface DefaultGovAction {
+    function perform() external;
+}
+
+contract CoreProposalCreator is Initializable, AccessControlUpgradeable {
+    bytes32 public constant PROPOSAL_CREATOR_ROLE = keccak256("PROPOSAL_CREATOR_ROLE");
+
+    address public l1ArbitrumTimelock;
+
+    struct UpgradeContracts {
+        address inbox;
+        address upgradeExecutor;
+        bool exists;
+    }
+
+    mapping(uint256 => UpgradeContracts) chainIDToUpgradeContracts;
+    uint256 minL1TimelockDelay;
+
+    address public constant RETRYABLE_TICKET_MAGIC = 0xa723C008e76E379c55599D2E4d93879BeaFDa79C;
+
+    event L2ChainInboxRegistered(
+        uint256 indexed chainID, address indexed inbox, address indexed upgradeExecutor
+    );
+    event L2ChainInboxRemoved(
+        uint256 indexed chainID, address indexed inbox, address indexed upgradeExecutor
+    );
+    event MinL1TimelockDelaySet(uint256 indexed newMinTimelockDelay);
+
+    event ProposalCreated(
+        uint256 targetChainID,
+        address govActionContract,
+        bytes govActionContractCalldata,
+        uint256 values,
+        bytes32 l1TimelockPrececessor,
+        bytes32 l1TimelockSalt,
+        uint256 l1TimelockDelay
+    );
+    event ProposalBatchCreated(
+        uint256[] targetChainIDs,
+        address[] govActionContracts,
+        bytes[] govActionContractCalldatas,
+        uint256[] values,
+        bytes32 l1TimelockPrececessor,
+        bytes32 l1TimelockSalt,
+        uint256 l1TimelockDelay
+    );
+
+    bytes public constant DEFAULT_GOV_ACTION_CALLDATA =
+        abi.encodeWithSelector(DefaultGovAction.perform.selector);
+    uint256 public constant DEFAULT_VALUE = 0;
+    bytes32 public constant DEFAULT_PREDECESSOR = bytes32(0);
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    modifier sufficientTimelockDelay(uint256 _l1TimelockDelay) {
+        require(
+            _l1TimelockDelay >= minL1TimelockDelay, "CoreProposalCreator: l1 timelock delay too low"
+        );
+        _;
+    }
+
+    function requireRegisteredChainID(uint256 _chainID) internal {
+        require(
+            chainIDToUpgradeContracts[_chainID].exists,
+            "CoreProposalCreator: unregisterded chain ID"
+        );
+    }
+
+    function initialize(
+        address _l1ArbitrumTimelock,
+        uint256[] memory _l2ChainIDs,
+        UpgradeContracts[] memory _upgradeContracts,
+        address _admin,
+        address _proposalCreator,
+        uint256 _minL1TimelockDelay
+    ) external initializer {
+        require(
+            _l2ChainIDs.length == _upgradeContracts.length,
+            "CoreProposalCreator: _l2ChainIDs _upgradeContracts length mismatch"
+        );
+        _setupRole(DEFAULT_ADMIN_ROLE, _admin);
+        _grantRole(PROPOSAL_CREATOR_ROLE, _proposalCreator);
+
+        l1ArbitrumTimelock = _l1ArbitrumTimelock;
+        for (uint256 i = 0; i < _l2ChainIDs.length; i++) {
+            _registerChain(_l2ChainIDs[i], _upgradeContracts[i]);
+        }
+        _setMinL1TimelockDelay(_minL1TimelockDelay);
+    }
+
+    function _setMinL1TimelockDelay(uint256 _minL1TimelockDelay) internal {
+        minL1TimelockDelay = _minL1TimelockDelay;
+        emit MinL1TimelockDelaySet(minL1TimelockDelay);
+    }
+
+    function _registerChain(uint256 _chainID, UpgradeContracts memory _upgradeContracts) internal {
+        require(_chainID != 0, "CoreProposalCreator: zero chainID");
+        require(_upgradeContracts.upgradeExecutor != address(0));
+        if (_chainID != 1) {
+            require(_upgradeContracts.inbox != address(0));
+        }
+        _upgradeContracts.exists = true;
+        chainIDToUpgradeContracts[_chainID] = _upgradeContracts;
+        emit L2ChainInboxRegistered(
+            _chainID, _upgradeContracts.inbox, _upgradeContracts.upgradeExecutor
+        );
+    }
+
+    function setMinL1TimelockDelay(uint256 _minL1TimelockDelay)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        _setMinL1TimelockDelay(_minL1TimelockDelay);
+    }
+
+    function registerChain(uint256 _chainID, UpgradeContracts memory _upgradeContracts)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        _registerChain(_chainID, _upgradeContracts);
+    }
+
+    function removeRegisteredL2Chain(uint256 _chainID) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        UpgradeContracts storage upgradeContracts = chainIDToUpgradeContracts[_chainID];
+        delete chainIDToUpgradeContracts[_chainID];
+        emit L2ChainInboxRemoved(_chainID, upgradeContracts.inbox, upgradeContracts.upgradeExecutor);
+    }
+
+    function createProposalBatch(
+        uint256[] memory _targetChainIDs,
+        address[] memory _govActionContracts,
+        bytes[] memory _govActionContractCalldatas,
+        uint256[] memory _values,
+        bytes32 _l1TimelockPrececessor,
+        bytes32 __l1TimelockSalt,
+        uint256 _l1TimelockDelay
+    ) external onlyRole(PROPOSAL_CREATOR_ROLE) {
+        _createProposalBatch(
+            _targetChainIDs,
+            _govActionContracts,
+            _govActionContractCalldatas,
+            _values,
+            _l1TimelockPrececessor,
+            __l1TimelockSalt,
+            _l1TimelockDelay
+        );
+    }
+
+    function createProposalBatchWithDefaultArgs(
+        uint256[] memory _targetChainIDs,
+        address[] memory _govActionContracts
+    ) external onlyRole(PROPOSAL_CREATOR_ROLE) {
+        bytes[] memory _govActionContractCalldatas;
+        uint256[] memory _values;
+        for (uint256 i = 0; i < _targetChainIDs.length; i++) {
+            _govActionContractCalldatas[i] = DEFAULT_GOV_ACTION_CALLDATA;
+            _values[i] = DEFAULT_VALUE;
+        }
+        _createProposalBatch(
+            _targetChainIDs,
+            _govActionContracts,
+            _govActionContractCalldatas,
+            _values,
+            DEFAULT_PREDECESSOR,
+            this.generateSalt(),
+            this.defaultL1TimelockDelay()
+        );
+    }
+
+    function _createProposalBatch(
+        uint256[] memory _targetChainIDs,
+        address[] memory _govActionContracts,
+        bytes[] memory _govActionContractCalldatas,
+        uint256[] memory _values,
+        bytes32 _l1TimelockPrececessor,
+        bytes32 _l1TimelockSalt,
+        uint256 _l1TimelockDelay
+    ) internal sufficientTimelockDelay(_l1TimelockDelay) {
+        require(
+            _targetChainIDs.length == _govActionContracts.length,
+            "CoreProposalCreator: length mismatch"
+        );
+        require(
+            _govActionContracts.length == _govActionContractCalldatas.length,
+            "CoreProposalCreator: length mismatch"
+        );
+        require(
+            _govActionContractCalldatas.length == _values.length,
+            "CoreProposalCreator: length mismatch"
+        );
+
+        address[] memory targets;
+        uint256[] memory values;
+        bytes[] memory payloads;
+        for (uint256 i = 0; i < _targetChainIDs.length; i++) {
+            requireRegisteredChainID(_targetChainIDs[i]);
+            (address target, uint256 value, bytes memory payload) = _getScheduleParams(
+                _targetChainIDs[i],
+                _govActionContracts[i],
+                _govActionContractCalldatas[i],
+                _values[i]
+            );
+            targets[i] = target;
+            values[i] = value;
+            payloads[i] = payload;
+        }
+        bytes memory l1TimelockCallData = abi.encodeWithSelector(
+            L1ArbitrumTimelock.scheduleBatch.selector,
+            targets,
+            values,
+            payloads,
+            _l1TimelockPrececessor,
+            _l1TimelockSalt,
+            _l1TimelockDelay
+        );
+        ArbSys(address(100)).sendTxToL1(l1ArbitrumTimelock, l1TimelockCallData);
+        emit ProposalBatchCreated(
+            _targetChainIDs,
+            _govActionContracts,
+            _govActionContractCalldatas,
+            _values,
+            _l1TimelockPrececessor,
+            _l1TimelockSalt,
+            _l1TimelockDelay
+        );
+    }
+
+    function createProposal(
+        uint256 _targetChainID,
+        address _govActionContract,
+        bytes memory _govActionContractCalldata,
+        uint256 _value,
+        bytes32 _l1TimelockPrececessor,
+        bytes32 _l1TimelockSalt,
+        uint256 _l1TimelockDelay
+    ) external onlyRole(PROPOSAL_CREATOR_ROLE) {
+        _createProposal(
+            _targetChainID,
+            _govActionContract,
+            _govActionContractCalldata,
+            _value,
+            _l1TimelockPrececessor,
+            _l1TimelockSalt,
+            _l1TimelockDelay
+        );
+    }
+
+    function createProposalWithDefaulArgs(uint256 _targetChainID, address _govActionContract)
+        external
+        onlyRole(PROPOSAL_CREATOR_ROLE)
+    {
+        _createProposal(
+            _targetChainID,
+            _govActionContract,
+            DEFAULT_GOV_ACTION_CALLDATA,
+            DEFAULT_VALUE,
+            DEFAULT_PREDECESSOR,
+            this.generateSalt(),
+            this.defaultL1TimelockDelay()
+        );
+    }
+
+    function _createProposal(
+        uint256 _targetChainID,
+        address _govActionContract,
+        bytes memory govActionContractCalldata,
+        uint256 _value,
+        bytes32 _l1TimelockPrececessor,
+        bytes32 _l1TimelockSalt,
+        uint256 _l1TimelockDelay
+    ) internal sufficientTimelockDelay(_l1TimelockDelay) {
+        requireRegisteredChainID(_targetChainID);
+        UpgradeContracts storage upgradeContracts = chainIDToUpgradeContracts[_targetChainID];
+        bytes memory upgradeExecutorCallData = abi.encodeWithSelector(
+            UpgradeExecutor.execute.selector, _govActionContract, govActionContractCalldata
+        );
+
+        (address target, uint256 value, bytes memory payload) = _getScheduleParams(
+            _targetChainID, _govActionContract, govActionContractCalldata, _value
+        );
+        bytes memory l1TimelockCallData = abi.encodeWithSelector(
+            L1ArbitrumTimelock.schedule.selector,
+            target,
+            value,
+            payload,
+            _l1TimelockPrececessor,
+            _l1TimelockSalt,
+            _l1TimelockDelay
+        );
+        ArbSys(address(100)).sendTxToL1(l1ArbitrumTimelock, l1TimelockCallData);
+        emit ProposalCreated(
+            _targetChainID,
+            _govActionContract,
+            govActionContractCalldata,
+            _value,
+            _l1TimelockPrececessor,
+            _l1TimelockSalt,
+            _l1TimelockDelay
+        );
+    }
+
+    function _getScheduleParams(
+        uint256 _targetChainID,
+        address _govActionContract,
+        bytes memory govActionContractCalldata,
+        uint256 _value
+    ) public view returns (address target, uint256 value, bytes memory payload) {
+        UpgradeContracts storage upgradeContracts = chainIDToUpgradeContracts[_targetChainID];
+
+        bytes memory upgradeExecutorCallData = abi.encodeWithSelector(
+            UpgradeExecutor.execute.selector, _govActionContract, govActionContractCalldata
+        );
+
+        address target;
+        uint256 value;
+        bytes memory paylod;
+        if (_targetChainID == 1) {
+            target = upgradeContracts.upgradeExecutor;
+            value = _value;
+            payload = upgradeExecutorCallData;
+        } else {
+            target = RETRYABLE_TICKET_MAGIC;
+            value = 0;
+            payload = abi.encode(
+                upgradeContracts.inbox,
+                upgradeContracts.upgradeExecutor,
+                _value,
+                0,
+                0,
+                upgradeExecutorCallData
+            );
+        }
+    }
+
+    function generateSalt() external view returns (bytes32) {
+        return keccak256(abi.encodePacked(block.timestamp, block.number));
+    }
+
+    function defaultL1TimelockDelay() external view returns (uint256) {
+        return minL1TimelockDelay;
+    }
+}

--- a/src/CoreProposalCreator.sol
+++ b/src/CoreProposalCreator.sol
@@ -163,17 +163,17 @@ contract CoreProposalCreator is Initializable, AccessControlUpgradeable {
         uint256[] memory _targetChainIDs,
         address[] memory _govActionContracts
     ) external onlyRole(PROPOSAL_CREATOR_ROLE) {
-        bytes[] memory _govActionContractCalldatas;
-        uint256[] memory _values;
+        bytes[] memory _defaultGovActionContractCalldatas;
+        uint256[] memory _defaultValues;
         for (uint256 i = 0; i < _targetChainIDs.length; i++) {
-            _govActionContractCalldatas[i] = DEFAULT_GOV_ACTION_CALLDATA;
-            _values[i] = DEFAULT_VALUE;
+            _defaultGovActionContractCalldatas[i] = DEFAULT_GOV_ACTION_CALLDATA;
+            _defaultValues[i] = DEFAULT_VALUE;
         }
         _createProposalBatch(
             _targetChainIDs,
             _govActionContracts,
-            _govActionContractCalldatas,
-            _values,
+            _defaultGovActionContractCalldatas,
+            _defaultValues,
             DEFAULT_PREDECESSOR,
             this.generateSalt(),
             this.defaultL1TimelockDelay()

--- a/src/CoreProposalCreator.sol
+++ b/src/CoreProposalCreator.sol
@@ -24,6 +24,7 @@ contract CoreProposalCreator is Initializable, AccessControlUpgradeable {
     }
 
     mapping(uint256 => UpgradeContracts) chainIDToUpgradeContracts;
+
     uint256 minL1TimelockDelay;
 
     address public constant RETRYABLE_TICKET_MAGIC = 0xa723C008e76E379c55599D2E4d93879BeaFDa79C;
@@ -71,7 +72,7 @@ contract CoreProposalCreator is Initializable, AccessControlUpgradeable {
         _;
     }
 
-    function requireRegisteredChainID(uint256 _chainID) internal {
+    function requireRegisteredChainID(uint256 _chainID) internal view {
         require(
             chainIDToUpgradeContracts[_chainID].exists,
             "CoreProposalCreator: unregisterded chain ID"
@@ -100,6 +101,13 @@ contract CoreProposalCreator is Initializable, AccessControlUpgradeable {
         _setMinL1TimelockDelay(_minL1TimelockDelay);
     }
 
+    function setMinL1TimelockDelay(uint256 _minL1TimelockDelay)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        _setMinL1TimelockDelay(_minL1TimelockDelay);
+    }
+
     function _setMinL1TimelockDelay(uint256 _minL1TimelockDelay) internal {
         minL1TimelockDelay = _minL1TimelockDelay;
         emit MinL1TimelockDelaySet(minL1TimelockDelay);
@@ -116,13 +124,6 @@ contract CoreProposalCreator is Initializable, AccessControlUpgradeable {
         emit L2ChainInboxRegistered(
             _chainID, _upgradeContracts.inbox, _upgradeContracts.upgradeExecutor
         );
-    }
-
-    function setMinL1TimelockDelay(uint256 _minL1TimelockDelay)
-        external
-        onlyRole(DEFAULT_ADMIN_ROLE)
-    {
-        _setMinL1TimelockDelay(_minL1TimelockDelay);
     }
 
     function registerChain(uint256 _chainID, UpgradeContracts memory _upgradeContracts)
@@ -282,7 +283,6 @@ contract CoreProposalCreator is Initializable, AccessControlUpgradeable {
         uint256 _l1TimelockDelay
     ) internal sufficientTimelockDelay(_l1TimelockDelay) {
         requireRegisteredChainID(_targetChainID);
-        UpgradeContracts storage upgradeContracts = chainIDToUpgradeContracts[_targetChainID];
         bytes memory upgradeExecutorCallData = abi.encodeWithSelector(
             UpgradeExecutor.execute.selector, _govActionContract, govActionContractCalldata
         );

--- a/src/CoreProposalCreator.sol
+++ b/src/CoreProposalCreator.sol
@@ -232,7 +232,7 @@ contract CoreProposalCreator is Initializable, AccessControlUpgradeable {
             _l1TimelockSalt,
             _l1TimelockDelay
         );
-        ArbSys(address(100)).sendTxToL1(l1ArbitrumTimelock, l1TimelockCallData);
+        sendTxToL1Timelock(l1TimelockCallData);
         emit ProposalBatchCreated(
             _targetChainIDs,
             _govActionContracts,
@@ -305,7 +305,7 @@ contract CoreProposalCreator is Initializable, AccessControlUpgradeable {
             _l1TimelockSalt,
             _l1TimelockDelay
         );
-        ArbSys(address(100)).sendTxToL1(l1ArbitrumTimelock, l1TimelockCallData);
+        sendTxToL1Timelock(l1TimelockCallData);
         emit ProposalCreated(
             _targetChainID,
             _govActionContract,
@@ -348,6 +348,10 @@ contract CoreProposalCreator is Initializable, AccessControlUpgradeable {
                 upgradeExecutorCallData
             );
         }
+    }
+
+    function sendTxToL1Timelock(bytes memory _l1TimelockCallData) internal {
+        ArbSys(address(100)).sendTxToL1(l1ArbitrumTimelock, _l1TimelockCallData);
     }
 
     function generateSalt() external view returns (bytes32) {

--- a/src/CoreProposalCreator.sol
+++ b/src/CoreProposalCreator.sol
@@ -115,9 +115,15 @@ contract CoreProposalCreator is Initializable, AccessControlUpgradeable {
 
     function _registerChain(uint256 _chainID, UpgradeContracts memory _upgradeContracts) internal {
         require(_chainID != 0, "CoreProposalCreator: zero chainID");
-        require(_upgradeContracts.upgradeExecutor != address(0));
+        require(
+            _upgradeContracts.upgradeExecutor != address(0),
+            "CoreProposalCreator: zero upgradeExecutor"
+        );
         if (_chainID != 1) {
-            require(_upgradeContracts.inbox != address(0));
+            require(
+                _upgradeContracts.inbox != address(0),
+                "CoreProposalCreator: zero inbox for L2 chain"
+            );
         }
         _upgradeContracts.exists = true;
         chainIDToUpgradeContracts[_chainID] = _upgradeContracts;

--- a/src/L1ArbitrumTimelock.sol
+++ b/src/L1ArbitrumTimelock.sol
@@ -29,8 +29,9 @@ contract L1ArbitrumTimelock is ArbitrumTimelock, L1ArbitrumMessenger {
     address public constant RETRYABLE_TICKET_MAGIC = 0xa723C008e76E379c55599D2E4d93879BeaFDa79C;
     /// @notice The inbox for the L2 where governance is based
     address public governanceChainInbox;
-    /// @notice The timelock of the governance contract on L2
+    /// @notice The timelock of the governance contract on L2 (unused / deprecated)
     address public l2Timelock;
+    /// @notice The address of the core proposal creator on L2
     address public coreProposalCreator;
 
     constructor() {
@@ -71,7 +72,7 @@ contract L1ArbitrumTimelock is ArbitrumTimelock, L1ArbitrumMessenger {
     function postUpgradeHook(address _coreProposalCreator) external {
         require(_coreProposalCreator != address(0), "L1ArbitrumTimelock: zero _coreProposalCreator");
         require(
-            coreProposalCreator != address(0), "L1ArbitrumTimelock: postUpgradeHook already called"
+            coreProposalCreator == address(0), "L1ArbitrumTimelock: postUpgradeHook already called"
         );
         coreProposalCreator = _coreProposalCreator;
     }


### PR DESCRIPTION
This is a potential quality-of-life improvement to governance; it introduces a new component in the core governor creation flow to make proposal creation/submission simpler and more easily observable by UIs / tooling. It makes no changes to governance's security model, timing, functionality, etc. 

Currently, core gov proposals are submitted with their "round trip" data — several layers of encoded calls — as a large bytes argument; this  bytes arg is generated by client side scripts and isn't easily human-readable, making submission potentially human-error prone.  

With this change, instead of the core governor's timelock calling ArbSys directly, it instead calls a CoreProposalCreator contract, which handles the round-trip proposal encoding on-chain. In the simplest case, the user only has to supply a "gov action contract address" and a "target chain id" as params.

The change requires a contract upgrade to the L1 Core governance timelock (note that hasn't yet been discussed / proposed to the DAO; we're just ideating here.) 

Since the upgrade would change the way proposals are to be submitted, we'd want to ensure to avoid race conditions with other proposals (i.e., where this proposal passing negates any others that are in progress). Some options:

- Simply ensure the timing of this change doesn't clash with others; i.e., that delegates wait sufficiently after this one is proposed before submitting new ones, taking advantage of the `predecessor` arg if helpful , etc.
- Submit this change as a non-emergency 7 of 12 action while there are no other proposals in progress.
-  Have the L1 timelock accept both versions of proposals (i.e., from CoreProposalCreator or from L2GovTimelock) for some period of time, or even indefinitely (this would be incurring some technical debt)