### PR TITLE
Security council nominations [Exploratory]

### DIFF
--- a/src/L2ArbitrumGovernor.sol
+++ b/src/L2ArbitrumGovernor.sol
@@ -202,7 +202,7 @@ contract L2ArbitrumGovernor is
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
-    ) internal override(GovernorUpgradeable, GovernorTimelockControlUpgradeable) {
+    ) internal virtual override(GovernorUpgradeable, GovernorTimelockControlUpgradeable) {
         GovernorTimelockControlUpgradeable._execute(
             proposalId, targets, values, calldatas, descriptionHash
         );
@@ -215,6 +215,7 @@ contract L2ArbitrumGovernor is
         bytes32 descriptionHash
     )
         internal
+        virtual
         override(GovernorUpgradeable, GovernorTimelockControlUpgradeable)
         returns (uint256)
     {

--- a/src/L2ArbitrumGovernor.sol
+++ b/src/L2ArbitrumGovernor.sol
@@ -164,6 +164,7 @@ contract L2ArbitrumGovernor is
     function state(uint256 proposalId)
         public
         view
+        virtual
         override(GovernorUpgradeable, GovernorTimelockControlUpgradeable)
         returns (ProposalState)
     {

--- a/src/security-council-mgmt/SecurityCouncilNominationsGovernor.sol
+++ b/src/security-council-mgmt/SecurityCouncilNominationsGovernor.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.16;
 
 import "../L2ArbitrumGovernor.sol";
-import "./SecurityCouncilManager.sol";
+import "./SecurityCouncilNominationsManager.sol";
 import "./interfaces/ISecurityCouncilManager.sol";
 
 
@@ -220,94 +220,5 @@ contract SecurityCouncilNominationsGovernor is L2ArbitrumGovernor {
     function _isCandidateEligible(uint256 proposalId, address candidate) internal view returns (bool) {
         uint256 electionId = nominationElections[proposalId].electionId;
         return nominationsManager.isCandidateUpForNomination(electionId, candidate);
-    }
-}
-
-// todo: constructor or initializer
-contract SecurityCouncilNominationsManager {
-    // todo: set these in the constructor / initializer
-    uint256 public targetNomineeCount;
-    Cohort public firstCohort;
-    uint256 public firstNominationStartTime;
-    uint256 public nominationFrequency;
-    SecurityCouncilManager public securityCouncilManager;
-    SecurityCouncilNominationsGovernor public nominationsGovernor;
-
-    // number of nomination elections that have been created
-    uint256 public nominationsCount;
-
-    // maps electionId to mapping of candidates up for nomination
-    mapping(uint256 => mapping(address => bool)) public isCandidateUpForNomination;
-
-    // maps NominationsManager's electionId to NominationsGovernor's proposalId
-    mapping(uint256 => uint256) public electionIdToProposalId;
-
-    modifier onlyGovernor {
-        require(msg.sender == address(nominationsGovernor), "Only the governor can call this");
-        _;
-    }
-
-    function createElection() external returns (uint256 electionId) {
-        require(block.timestamp >= firstNominationStartTime + nominationFrequency * nominationsCount, "Not enough time has passed since the last election");
-
-        electionId = nominationsCount;
-
-        address[] memory targets = new address[](1);
-        uint256[] memory values = new uint256[](1);
-        bytes[] memory calldatas = new bytes[](1);
-
-        targets[0] = address(this);
-        values[0] = 0;
-        calldatas[0] = abi.encodeWithSelector(this.executeFromGovernor.selector, electionId);
-
-        // TODO: set the description to something meaningful
-        uint256 proposalId = nominationsGovernor.propose(
-            targets,
-            values,
-            calldatas,
-            "TODO"
-        );
-
-        electionIdToProposalId[electionId] = proposalId;
-
-        nominationsCount++;
-    }
-
-    function nominateCandidate(uint256 electionId, address account) external {
-        IGovernorUpgradeable.ProposalState state = nominationsGovernor.state(electionIdToProposalId[electionId]);
-        require(state == IGovernorUpgradeable.ProposalState.Active, "Proposal is not active");
-
-        // todo: check to make sure the candidate is eligible (not part of the other cohort, etc.)
-
-        isCandidateUpForNomination[electionId][account] = true;
-    }
-
-    // vote has finished, some number of candidates have been nominated
-    // governor contract calls this function
-    function executeFromGovernor(uint256 electionId) external onlyGovernor {
-        uint256 numNominated = nominationsGovernor.successfullyNominatedCandidatesCount(electionIdToProposalId[electionId]);
-
-        if (numNominated > targetNomineeCount) {
-            // TODO:
-            // call some ElectionsManager to start the election with the nominated candidates
-            // the ElectionsManager or ElectionsGovernor will call either this contract or the NominationsGovernor to check which candidates are eligible when someone casts a vote
-            return;
-        }
-
-        address[] memory nominees;
-        if (numNominated < targetNomineeCount) {
-            // todo: randomly select some number of candidates from current cohort to add to the nominees
-            // nominees = ...
-        }
-        else {
-            nominees = nominationsGovernor.successfullyNominatedCandidates(electionIdToProposalId[electionId]);
-        }
-        
-        // call the SecurityCouncilManager to switch out the security council members
-        securityCouncilManager.executeElectionResult(nominees, cohortOfElection(electionId));
-    }
-
-    function cohortOfElection(uint256 electionId) public view returns (Cohort) {
-        return Cohort((uint256(firstCohort) + electionId) % 2);
     }
 }

--- a/src/security-council-mgmt/SecurityCouncilNominationsGovernor.sol
+++ b/src/security-council-mgmt/SecurityCouncilNominationsGovernor.sol
@@ -197,6 +197,7 @@ contract SecurityCouncilNominationsGovernor is L2ArbitrumGovernor {
         uint256 proposalId = super.propose(targets, values, calldatas, description);
 
         // set the electionId for this proposal
+        // alternatively, we can decode the calldata and get the electionId from there
         uint256 electionId = nominationsManager.nominationsCount();
         nominationElections[proposalId].electionId = electionId;
 

--- a/src/security-council-mgmt/SecurityCouncilNominationsGovernor.sol
+++ b/src/security-council-mgmt/SecurityCouncilNominationsGovernor.sol
@@ -8,8 +8,14 @@ import "./interfaces/ISecurityCouncilManager.sol";
 
 // narrows a set of candidates down to a set of nominees
 // todo: setter for the nominations manager
+// todo: ERC165
 contract SecurityCouncilNominationsGovernor is L2ArbitrumGovernor {
     // override all GovernorCountingSimpleUpgradeable functions
+
+    // override all GovernorTimelockControlUpgradeable functions 
+    // (and L2ArbitrumGovernor functions that override GovernorTimelockControlUpgradeable)
+    // because we don't need a timelock
+
     // we also don't need GovernorPreventLateQuorumUpgradeable
     // so we set the minPeriodAfterQuorum to 0?
 
@@ -28,14 +34,12 @@ contract SecurityCouncilNominationsGovernor is L2ArbitrumGovernor {
     mapping(uint256 => NominationElection) nominationElections;
 
     /// @param _token The token to read vote delegation from
-    /// @param _timelock A time lock for proposal execution
     /// @param _owner The executor through which all upgrades should be finalised
     /// @param _votingDelay The delay between a proposal submission and voting starts
     /// @param _votingPeriod The period for which the vote lasts
     /// @param _quorumNumerator The proportion of the circulating supply required to reach a quorum
     function initialize(
         IVotesUpgradeable _token,
-        TimelockControllerUpgradeable _timelock,
         address _owner,
         SecurityCouncilNominationsManager _nominationsManager,
         uint256 _votingDelay,
@@ -46,7 +50,7 @@ contract SecurityCouncilNominationsGovernor is L2ArbitrumGovernor {
         __GovernorSettings_init(_votingDelay, _votingPeriod, 0);
         // __GovernorCountingSimple_init(); // we are overriding this
         __GovernorVotes_init(_token);
-        __GovernorTimelockControl_init(_timelock);
+        // __GovernorTimelockControl_init(_timelock); // we are overriding this too
         __GovernorVotesQuorumFraction_init(_quorumNumerator);
         __GovernorPreventLateQuorum_init(0); // set this to 0 to disable prevent late quorum?
         _transferOwnership(_owner);
@@ -130,6 +134,58 @@ contract SecurityCouncilNominationsGovernor is L2ArbitrumGovernor {
     }
 
     ////////////// End GovernorCountingSimple Overrides //////////////
+
+    ////////////// GovernorTimelockControl Overrides //////////////
+
+    // should these view functions just revert?
+
+    function state(uint256 proposalId) public view virtual override returns (ProposalState) {
+        return GovernorUpgradeable.state(proposalId);
+    }
+
+    function timelock() public view virtual override returns (address) {
+        return address(0);
+    }
+
+    function proposalEta(uint256) public view virtual override returns (uint256) {
+        return 0;
+    }
+
+    function queue(
+        address[] memory,
+        uint256[] memory,
+        bytes[] memory,
+        bytes32
+    ) public virtual override returns (uint256) {
+        revert("Unsupported");
+    }
+
+    function _execute(
+        uint256 proposalId,
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 descriptionHash
+    ) internal override {
+        GovernorUpgradeable._execute(
+            proposalId, targets, values, calldatas, descriptionHash
+        );
+    }
+
+    function _cancel(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 descriptionHash
+    ) internal virtual override returns (uint256) {
+        return GovernorUpgradeable._cancel(targets, values, calldatas, descriptionHash);
+    }
+
+    function updateTimelock(TimelockControllerUpgradeable newTimelock) external virtual override {
+        revert("Unsupported");
+    }
+
+    ////////////// End GovernorTimelockControl Overrides //////////////
 
     // override propose such that only the manager contract can call it
     function propose(

--- a/src/security-council-mgmt/SecurityCouncilNominationsGovernor.sol
+++ b/src/security-council-mgmt/SecurityCouncilNominationsGovernor.sol
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import "../L2ArbitrumGovernor.sol";
+import "./SecurityCouncilManager.sol";
+import "./interfaces/ISecurityCouncilManager.sol";
+
+
+// narrows a set of candidates down to a set of nominees
+// todo: setter for the nominations manager
+contract SecurityCouncilNominationsGovernor is L2ArbitrumGovernor {
+    // override all GovernorCountingSimpleUpgradeable functions
+    // we also don't need GovernorPreventLateQuorumUpgradeable
+    // so we set the minPeriodAfterQuorum to 0?
+
+    // also override propose to make sure only the manager can call it
+
+    struct NominationElection {
+        uint256 electionId; // NominationsManager's electionId
+        mapping(address => uint256) nominationsTokensUsed;
+        mapping(address => uint256) nominationsVotes;
+        address[] successfullyNominatedCandidates;
+    }
+
+    SecurityCouncilNominationsManager public nominationsManager;
+
+    // proposalId => GovernorNominationElection
+    mapping(uint256 => NominationElection) nominationElections;
+
+    /// @param _token The token to read vote delegation from
+    /// @param _timelock A time lock for proposal execution
+    /// @param _owner The executor through which all upgrades should be finalised
+    /// @param _votingDelay The delay between a proposal submission and voting starts
+    /// @param _votingPeriod The period for which the vote lasts
+    /// @param _quorumNumerator The proportion of the circulating supply required to reach a quorum
+    function initialize(
+        IVotesUpgradeable _token,
+        TimelockControllerUpgradeable _timelock,
+        address _owner,
+        SecurityCouncilNominationsManager _nominationsManager,
+        uint256 _votingDelay,
+        uint256 _votingPeriod,
+        uint256 _quorumNumerator // 0.2%, required for any candidate to become a nominee for next phases
+    ) external initializer {
+        __Governor_init("TODO: some name here like NominationsGovernor or something");
+        __GovernorSettings_init(_votingDelay, _votingPeriod, 0);
+        // __GovernorCountingSimple_init(); // we are overriding this
+        __GovernorVotes_init(_token);
+        __GovernorTimelockControl_init(_timelock);
+        __GovernorVotesQuorumFraction_init(_quorumNumerator);
+        __GovernorPreventLateQuorum_init(0); // set this to 0 to disable prevent late quorum?
+        _transferOwnership(_owner);
+
+        nominationsManager = _nominationsManager;
+    }
+
+    modifier onlyManager {
+        require(msg.sender == address(nominationsManager), "Only the manager can call this");
+        _;
+    }
+
+    ////////////// GovernorCountingSimple Overrides //////////////
+
+    function COUNTING_MODE() public pure virtual override(GovernorCountingSimpleUpgradeable, IGovernorUpgradeable) returns (string memory) {
+        return "TODO: ???";
+    }
+
+    function hasVoted(
+        uint256 proposalId, 
+        address account
+    ) 
+        public 
+        view 
+        override(GovernorCountingSimpleUpgradeable, IGovernorUpgradeable) 
+        returns (bool) 
+    {
+        // should this return true if they've cast any amount of votes? or if they've cast all of their votes?
+        revert("TODO");
+    }
+
+    // unsupported because it is supposed to return for, against, abstain. but that doesn't make sense for nominations
+    function proposalVotes(
+        uint256
+    ) public pure override(GovernorCountingSimpleUpgradeable) returns (uint256, uint256, uint256) {
+        revert("Unsupported");
+    }
+
+    // there is no minimum quorum for nominations, so we just return true
+    function _quorumReached(uint256) internal pure override(GovernorCountingSimpleUpgradeable, GovernorUpgradeable) returns (bool) {
+        return true;
+    }
+
+    // the vote always succeeds, so we just return true
+    function _voteSucceeded(uint256) internal pure override(GovernorCountingSimpleUpgradeable, GovernorUpgradeable) returns (bool) {
+        return true;
+    }
+
+    function _countVote(
+        uint256 proposalId,
+        address account,
+        uint8,
+        uint256 weight,
+        bytes memory params
+    ) internal virtual override(GovernorCountingSimpleUpgradeable, GovernorUpgradeable) {
+        // let's say params is (address candidate, uint256 tokens)
+        (address candidate, uint256 tokens) = abi.decode(params, (address, uint256));
+
+        require(_isCandidateEligible(proposalId, candidate), "Candidate is not eligible");
+
+        NominationElection storage election = nominationElections[proposalId];
+
+        // weight is the number of tokens that account has at the time of the vote
+        // make sure tokens + previously used tokens is less than or equal to weight
+        uint256 previouslyUsedTokens = election.nominationsTokensUsed[account];
+        require(tokens + previouslyUsedTokens <= weight, "Not enough tokens to cast this vote");
+
+        // add to nominationsTokensUsed
+        election.nominationsTokensUsed[account] = previouslyUsedTokens + tokens;
+
+        // add tokens to the candidate
+        uint256 oldVotesForCandidate = election.nominationsVotes[candidate];
+        election.nominationsVotes[candidate] = oldVotesForCandidate + tokens;
+
+        // if this vote put the candidate over the line, push to successfullyNominatedCandidates
+        uint256 votesNeeded = quorum(proposalSnapshot(proposalId));
+        if (oldVotesForCandidate < votesNeeded && oldVotesForCandidate + tokens >= votesNeeded) {
+            election.successfullyNominatedCandidates.push(candidate);
+            // emit some event like CandidateSuccessfullyNominated(proposalId, candidate);
+        }
+    }
+
+    ////////////// End GovernorCountingSimple Overrides //////////////
+
+    // override propose such that only the manager contract can call it
+    function propose(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description
+    ) public virtual override(GovernorUpgradeable, IGovernorUpgradeable) onlyManager returns (uint256) {
+        uint256 proposalId = super.propose(targets, values, calldatas, description);
+
+        // set the electionId for this proposal
+        uint256 electionId = nominationsManager.nominationsCount();
+        nominationElections[proposalId].electionId = electionId;
+
+        return proposalId;
+    }
+
+    // returns true if the candidate has enough votes to be nominated
+    function isCandidateSuccessfullyNominated(uint256 proposalId, address candidate) public view returns (bool) {
+        return nominationElections[proposalId].nominationsVotes[candidate] >= quorum(proposalSnapshot(proposalId));
+    }
+
+    function successfullyNominatedCandidatesCount(uint256 proposalId) public view returns (uint256) {
+        return nominationElections[proposalId].successfullyNominatedCandidates.length;
+    }
+
+    function successfullyNominatedCandidates(uint256 proposalId) public view returns (address[] memory) {
+        return nominationElections[proposalId].successfullyNominatedCandidates;
+    }
+
+    // check the manager contract to see if the candidate is eligible
+    function _isCandidateEligible(uint256 proposalId, address candidate) internal view returns (bool) {
+        uint256 electionId = nominationElections[proposalId].electionId;
+        return nominationsManager.isCandidateUpForNomination(electionId, candidate);
+    }
+}
+
+// todo: constructor or initializer
+contract SecurityCouncilNominationsManager {
+    // todo: set these in the constructor / initializer
+    uint256 public targetNomineeCount;
+    Cohort public firstCohort;
+    uint256 public firstNominationStartTime;
+    uint256 public nominationFrequency;
+    SecurityCouncilManager public securityCouncilManager;
+    SecurityCouncilNominationsGovernor public nominationsGovernor;
+
+    // number of nomination elections that have been created
+    uint256 public nominationsCount;
+
+    // maps electionId to mapping of candidates up for nomination
+    mapping(uint256 => mapping(address => bool)) public isCandidateUpForNomination;
+
+    // maps NominationsManager's electionId to NominationsGovernor's proposalId
+    mapping(uint256 => uint256) public electionIdToProposalId;
+
+    modifier onlyGovernor {
+        require(msg.sender == address(nominationsGovernor), "Only the governor can call this");
+        _;
+    }
+
+    function createElection() external returns (uint256 electionId) {
+        require(block.timestamp >= firstNominationStartTime + nominationFrequency * nominationsCount, "Not enough time has passed since the last election");
+
+        electionId = nominationsCount;
+
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+
+        targets[0] = address(this);
+        values[0] = 0;
+        calldatas[0] = abi.encodeWithSelector(this.executeFromGovernor.selector, electionId);
+
+        // TODO: set the description to something meaningful
+        uint256 proposalId = nominationsGovernor.propose(
+            targets,
+            values,
+            calldatas,
+            "TODO"
+        );
+
+        electionIdToProposalId[electionId] = proposalId;
+
+        nominationsCount++;
+    }
+
+    function nominateCandidate(uint256 electionId, address account) external {
+        IGovernorUpgradeable.ProposalState state = nominationsGovernor.state(electionIdToProposalId[electionId]);
+        require(state == IGovernorUpgradeable.ProposalState.Active, "Proposal is not active");
+
+        // todo: check to make sure the candidate is eligible (not part of the other cohort, etc.)
+
+        isCandidateUpForNomination[electionId][account] = true;
+    }
+
+    // vote has finished, some number of candidates have been nominated
+    // governor contract calls this function
+    function executeFromGovernor(uint256 electionId) external onlyGovernor {
+        uint256 numNominated = nominationsGovernor.successfullyNominatedCandidatesCount(electionIdToProposalId[electionId]);
+
+        if (numNominated > targetNomineeCount) {
+            // TODO:
+            // call some ElectionsManager to start the election with the nominated candidates
+            // the ElectionsManager or ElectionsGovernor will call either this contract or the NominationsGovernor to check which candidates are eligible when someone casts a vote
+            return;
+        }
+
+        address[] memory nominees;
+        if (numNominated < targetNomineeCount) {
+            // todo: randomly select some number of candidates from current cohort to add to the nominees
+            // nominees = ...
+        }
+        else {
+            nominees = nominationsGovernor.successfullyNominatedCandidates(electionIdToProposalId[electionId]);
+        }
+        
+        // call the SecurityCouncilManager to switch out the security council members
+        securityCouncilManager.executeElectionResult(nominees, cohortOfElection(electionId));
+    }
+
+    function cohortOfElection(uint256 electionId) public view returns (Cohort) {
+        return Cohort((uint256(firstCohort) + electionId) % 2);
+    }
+}

--- a/src/security-council-mgmt/SecurityCouncilNominationsGovernor2.sol
+++ b/src/security-council-mgmt/SecurityCouncilNominationsGovernor2.sol
@@ -191,6 +191,7 @@ abstract contract SecurityCouncilNominationsGovernor2 is
         uint256 proposalId = super.propose(targets, values, calldatas, description);
 
         // set the electionId for this proposal
+        // alternatively, we can decode the calldata and get the electionId from there
         uint256 electionId = nominationsManager.nominationsCount();
         nominationElections[proposalId].electionId = electionId;
 

--- a/src/security-council-mgmt/SecurityCouncilNominationsGovernor2.sol
+++ b/src/security-council-mgmt/SecurityCouncilNominationsGovernor2.sol
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorSettingsUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorVotesUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorPreventLateQuorumUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+import "../L2ArbitrumGovernor.sol";
+import "./SecurityCouncilNominationsManager.sol";
+import "./interfaces/ISecurityCouncilManager.sol";
+
+abstract contract ArbitrumGovernorVotesQuorumFractionUpgradeable is Initializable, GovernorVotesQuorumFractionUpgradeable {
+    /// @notice address for which votes will not be counted toward quorum
+    /// @dev    A portion of the Arbitrum tokens will be held by entities (eg the treasury) that
+    ///         are not eligible to vote. However, even if their voting/delegation is restricted their
+    ///         tokens will still count towards the total supply, and will therefore affect the quorom.
+    ///         Restricted addresses should be forced to delegate their votes to this special exclude
+    ///         addresses which is not counted when calculating quorum
+    ///         Example address that should be excluded: DAO treasury, foundation, unclaimed tokens,
+    ///         burned tokens and swept (see TokenDistributor) tokens.
+    ///         Note that Excluded Address is a readable name with no code of PK associated with it, and thus can't vote.
+    address public constant EXCLUDE_ADDRESS = address(0xA4b86);
+
+    function __ArbitrumGovernorVotesQuorumFraction_init(uint256 quorumNumeratorValue) internal onlyInitializing {
+        __GovernorVotesQuorumFraction_init(quorumNumeratorValue);
+    }
+
+    /// @notice Get "circulating" votes supply; i.e., total minus excluded vote exclude address.
+    function getPastCirculatingSupply(uint256 blockNumber) public view virtual returns (uint256) {
+        return
+            token.getPastTotalSupply(blockNumber) - token.getPastVotes(EXCLUDE_ADDRESS, blockNumber);
+    }
+
+    /// @notice Calculates the quorum size, excludes token delegated to the exclude address
+    function quorum(uint256 blockNumber)
+        public
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        return (getPastCirculatingSupply(blockNumber) * quorumNumerator(blockNumber))
+            / quorumDenominator();
+    }
+
+    /// @inheritdoc GovernorVotesQuorumFractionUpgradeable
+    function quorumDenominator()
+        public
+        pure
+        virtual
+        override
+        returns (uint256)
+    {
+        // update to 10k to allow for higher precision
+        return 10_000;
+    }
+    
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[50] private __gap;
+}
+
+// this contract is the same as SecurityCouncilNominationsGovernor, 
+// but instead of using L2ArbitrumGovernor as a parent and overriding some of its modules like counting/timelock, 
+// it uses OZ governor contracts as parents and just inherits what it needs
+abstract contract SecurityCouncilNominationsGovernor2 is
+    Initializable,
+    GovernorUpgradeable,
+    GovernorVotesUpgradeable,
+    ArbitrumGovernorVotesQuorumFractionUpgradeable,
+    GovernorSettingsUpgradeable,
+    OwnableUpgradeable
+{
+    struct NominationElection {
+        uint256 electionId; // NominationsManager's electionId
+        mapping(address => uint256) nominationsTokensUsed;
+        mapping(address => uint256) nominationsVotes;
+        address[] successfullyNominatedCandidates;
+    }
+
+    SecurityCouncilNominationsManager public nominationsManager;
+
+    // proposalId => GovernorNominationElection
+    mapping(uint256 => NominationElection) nominationElections;
+
+    /// @param _token The token to read vote delegation from
+    /// @param _owner The executor through which all upgrades should be finalised
+    /// @param _votingDelay The delay between a proposal submission and voting starts
+    /// @param _votingPeriod The period for which the vote lasts
+    /// @param _quorumNumerator The proportion of the circulating supply required to reach a quorum
+    function initialize(
+        IVotesUpgradeable _token,
+        address _owner,
+        SecurityCouncilNominationsManager _nominationsManager,
+        uint256 _votingDelay,
+        uint256 _votingPeriod,
+        uint256 _quorumNumerator // 0.2%, required for any candidate to become a nominee for next phases
+    ) external initializer {
+        __Governor_init("TODO: some name here like NominationsGovernor or something");
+        __GovernorVotes_init(_token);
+        __ArbitrumGovernorVotesQuorumFraction_init(_quorumNumerator);
+        __GovernorSettings_init(_votingDelay, _votingPeriod, 0);
+        _transferOwnership(_owner);
+
+        nominationsManager = _nominationsManager;
+    }
+
+    modifier onlyManager {
+        require(msg.sender == address(nominationsManager), "Only the manager can call this");
+        _;
+    }
+
+    ////////////// Counting //////////////
+
+    function COUNTING_MODE() public pure virtual override returns (string memory) {
+        return "TODO: ???";
+    }
+
+    function hasVoted(
+        uint256 proposalId, 
+        address account
+    ) 
+        public 
+        view 
+        override
+        returns (bool) 
+    {
+        // should this return true if they've cast any amount of votes? or if they've cast all of their votes?
+        revert("TODO");
+    }
+
+    // there is no minimum quorum for nominations, so we just return true
+    function _quorumReached(uint256) internal pure override returns (bool) {
+        return true;
+    }
+
+    // the vote always succeeds, so we just return true
+    function _voteSucceeded(uint256) internal pure override returns (bool) {
+        return true;
+    }
+
+    function _countVote(
+        uint256 proposalId,
+        address account,
+        uint8,
+        uint256 weight,
+        bytes memory params
+    ) internal virtual override {
+        // let's say params is (address candidate, uint256 tokens)
+        (address candidate, uint256 tokens) = abi.decode(params, (address, uint256));
+
+        require(_isCandidateEligible(proposalId, candidate), "Candidate is not eligible");
+
+        NominationElection storage election = nominationElections[proposalId];
+
+        // weight is the number of tokens that account has at the time of the vote
+        // make sure tokens + previously used tokens is less than or equal to weight
+        uint256 previouslyUsedTokens = election.nominationsTokensUsed[account];
+        require(tokens + previouslyUsedTokens <= weight, "Not enough tokens to cast this vote");
+
+        // add to nominationsTokensUsed
+        election.nominationsTokensUsed[account] = previouslyUsedTokens + tokens;
+
+        // add tokens to the candidate
+        uint256 oldVotesForCandidate = election.nominationsVotes[candidate];
+        election.nominationsVotes[candidate] = oldVotesForCandidate + tokens;
+
+        // if this vote put the candidate over the line, push to successfullyNominatedCandidates
+        uint256 votesNeeded = quorum(proposalSnapshot(proposalId));
+        if (oldVotesForCandidate < votesNeeded && oldVotesForCandidate + tokens >= votesNeeded) {
+            election.successfullyNominatedCandidates.push(candidate);
+            // emit some event like CandidateSuccessfullyNominated(proposalId, candidate);
+        }
+    }
+
+    ////////////// End Counting //////////////
+
+    ////////////// Other Overrides //////////////
+
+    // override propose such that only the manager contract can call it
+    function propose(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description
+    ) public virtual override onlyManager returns (uint256) {
+        uint256 proposalId = super.propose(targets, values, calldatas, description);
+
+        // set the electionId for this proposal
+        uint256 electionId = nominationsManager.nominationsCount();
+        nominationElections[proposalId].electionId = electionId;
+
+        return proposalId;
+    }
+
+    function proposalThreshold() public view virtual override(GovernorSettingsUpgradeable, GovernorUpgradeable) returns (uint256) {
+        return 0;
+    }
+
+    /// @notice Allows the owner to make calls from the governor
+    /// @dev    See {L2ArbitrumGovernor-relay}
+    function relay(address target, uint256 value, bytes calldata data)
+        external
+        virtual
+        override
+        onlyOwner
+    {
+        AddressUpgradeable.functionCallWithValue(target, data, value);
+    }
+
+    ////////////// End Other Overrides //////////////
+
+    // returns true if the candidate has enough votes to be nominated
+    function isCandidateSuccessfullyNominated(uint256 proposalId, address candidate) public view returns (bool) {
+        return nominationElections[proposalId].nominationsVotes[candidate] >= quorum(proposalSnapshot(proposalId));
+    }
+
+    function successfullyNominatedCandidatesCount(uint256 proposalId) public view returns (uint256) {
+        return nominationElections[proposalId].successfullyNominatedCandidates.length;
+    }
+
+    function successfullyNominatedCandidates(uint256 proposalId) public view returns (address[] memory) {
+        return nominationElections[proposalId].successfullyNominatedCandidates;
+    }
+
+    // check the manager contract to see if the candidate is eligible
+    function _isCandidateEligible(uint256 proposalId, address candidate) internal view returns (bool) {
+        uint256 electionId = nominationElections[proposalId].electionId;
+        return nominationsManager.isCandidateUpForNomination(electionId, candidate);
+    }
+}

--- a/src/security-council-mgmt/SecurityCouncilNominationsManager.sol
+++ b/src/security-council-mgmt/SecurityCouncilNominationsManager.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import "@openzeppelin/contracts-upgradeable/governance/IGovernorUpgradeable.sol";
+
+import "./SecurityCouncilManager.sol";
+import "./SecurityCouncilNominationsGovernor.sol";
+
+// todo: constructor or initializer
+contract SecurityCouncilNominationsManager {
+    // todo: set these in the constructor / initializer
+    uint256 public targetNomineeCount;
+    Cohort public firstCohort;
+    uint256 public firstNominationStartTime;
+    uint256 public nominationFrequency;
+    SecurityCouncilManager public securityCouncilManager;
+    SecurityCouncilNominationsGovernor public nominationsGovernor;
+
+    // number of nomination elections that have been created
+    uint256 public nominationsCount;
+
+    // maps electionId to mapping of candidates up for nomination
+    mapping(uint256 => mapping(address => bool)) public isCandidateUpForNomination;
+
+    // maps NominationsManager's electionId to NominationsGovernor's proposalId
+    mapping(uint256 => uint256) public electionIdToProposalId;
+
+    modifier onlyGovernor {
+        require(msg.sender == address(nominationsGovernor), "Only the governor can call this");
+        _;
+    }
+
+    function createElection() external returns (uint256 electionId) {
+        require(block.timestamp >= firstNominationStartTime + nominationFrequency * nominationsCount, "Not enough time has passed since the last election");
+
+        electionId = nominationsCount;
+
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+
+        targets[0] = address(this);
+        values[0] = 0;
+        calldatas[0] = abi.encodeWithSelector(this.executeFromGovernor.selector, electionId);
+
+        // TODO: set the description to something meaningful
+        uint256 proposalId = nominationsGovernor.propose(
+            targets,
+            values,
+            calldatas,
+            "TODO"
+        );
+
+        electionIdToProposalId[electionId] = proposalId;
+
+        nominationsCount++;
+    }
+
+    function nominateCandidate(uint256 electionId, address account) external {
+        IGovernorUpgradeable.ProposalState state = nominationsGovernor.state(electionIdToProposalId[electionId]);
+        require(state == IGovernorUpgradeable.ProposalState.Active, "Proposal is not active");
+
+        // todo: check to make sure the candidate is eligible (not part of the other cohort, etc.)
+
+        isCandidateUpForNomination[electionId][account] = true;
+    }
+
+    // vote has finished, some number of candidates have been nominated
+    // governor contract calls this function
+    function executeFromGovernor(uint256 electionId) external onlyGovernor {
+        uint256 numNominated = nominationsGovernor.successfullyNominatedCandidatesCount(electionIdToProposalId[electionId]);
+
+        if (numNominated > targetNomineeCount) {
+            // TODO:
+            // call some ElectionsManager to start the election with the nominated candidates
+            // the ElectionsManager or ElectionsGovernor will call either this contract or the NominationsGovernor to check which candidates are eligible when someone casts a vote
+            return;
+        }
+
+        address[] memory nominees;
+        if (numNominated < targetNomineeCount) {
+            // todo: randomly select some number of candidates from current cohort to add to the nominees
+            // nominees = ...
+        }
+        else {
+            nominees = nominationsGovernor.successfullyNominatedCandidates(electionIdToProposalId[electionId]);
+        }
+        
+        // call the SecurityCouncilManager to switch out the security council members
+        securityCouncilManager.executeElectionResult(nominees, cohortOfElection(electionId));
+    }
+
+    function cohortOfElection(uint256 electionId) public view returns (Cohort) {
+        return Cohort((uint256(firstCohort) + electionId) % 2);
+    }
+}

--- a/src/security-council-mgmt/SecurityCouncilNominationsManager.sol
+++ b/src/security-council-mgmt/SecurityCouncilNominationsManager.sol
@@ -74,6 +74,9 @@ contract SecurityCouncilNominationsManager {
             // TODO:
             // call some ElectionsManager to start the election with the nominated candidates
             // the ElectionsManager or ElectionsGovernor will call either this contract or the NominationsGovernor to check which candidates are eligible when someone casts a vote
+            // ... or we can read out the entire list of successfullyNominatedCandidates and pass that along, but the list could be pretty long
+
+            // or maybe we don't use another manager contract at all, just have this contract manage the nominations governor as well as the phase 2&3 governor
             return;
         }
 


### PR DESCRIPTION
This is a potential implementation / tentative design of Security Council Elections phase 1 voting.

The basic idea is to have two contracts: a governor and a manger.

The general flow is like this:

1. Anyone calls `createElection` on the manager
2. Manager calls `propose` on the governor (with the target of the proposal being the manager)
3. People vote via the governor's `castVoteWithReasonAndParams`
4. Governor calls back to manager once voting is done
5. Manager decides to move on to phase 2&3 or skip directly to calling `SecurityCouncilManager.executeElectionResult` 

This code has lots of todo's as this PR is only meant to see what this design could roughly look like. 

### Governor
The governor contract is responsible for counting votes and keeping track of which candidates have passed the 0.2% threshold. 

`SecurityCouncilNominationsGovernor` extends `L2ArbitrumGovernor` and overrides functions that are not necessary or must behave differently, such as `_countVote` and `queue`.

`SecurityCouncilNominationsGovernor2` is an alternative implementation that is meant to be functionally the same, but instead of extending `L2ArbitrumGovernor`, it extends only the necessary OpenZeppelin governor contracts. 

For `SecurityCouncilNominationsGovernor2` there is an abstract contract that handles Arbitrum specific quorum logic:

```
abstract contract ArbitrumGovernorVotesQuorumFractionUpgradeable is Initializable, GovernorVotesQuorumFractionUpgradeable
```

### Manager
The `SecurityCouncilNominationsManager` contract creates elections every 6 months, checks and stores eligibility of candidates when they are put up for nomination (like make sure they aren't part of the other SC Cohort), and handles the result given by the governor once voting ends.