### PR TITLE
allow for multiple cohortUpdators in SecurityCouncilManager.initialize

### DIFF
--- a/src/security-council-mgmt/SecurityCouncilManager.sol
+++ b/src/security-council-mgmt/SecurityCouncilManager.sol
@@ -58,10 +58,13 @@ contract SecurityCouncilManager is
         septemberCohort = _septemberCohort;
         // TODO: ensure march + september cohort = all signers?
         _grantRole(DEFAULT_ADMIN_ROLE, _roles.admin);
-        _grantRole(ELECTION_EXECUTOR_ROLE, _roles.cohortUpdator);
         _grantRole(MEMBER_ADDER_ROLE, _roles.memberAdder);
         _grantRole(MEMBER_REMOVER_ROLE, _roles.memberRemover);
         _grantRole(MEMBER_ROTATOR_ROLE, _roles.memberRotator);
+
+        for (uint256 i = 0; i < _roles.cohortUpdator.length; i++) {
+            _grantRole(ELECTION_EXECUTOR_ROLE, _roles.cohortUpdator[i]);
+        }
 
         _setTargetContracts(_targetContracts);
     }

--- a/src/security-council-mgmt/SecurityCouncilManager.sol
+++ b/src/security-council-mgmt/SecurityCouncilManager.sol
@@ -62,8 +62,8 @@ contract SecurityCouncilManager is
         _grantRole(MEMBER_REMOVER_ROLE, _roles.memberRemover);
         _grantRole(MEMBER_ROTATOR_ROLE, _roles.memberRotator);
 
-        for (uint256 i = 0; i < _roles.cohortUpdator.length; i++) {
-            _grantRole(ELECTION_EXECUTOR_ROLE, _roles.cohortUpdator[i]);
+        for (uint256 i = 0; i < _roles.cohortUpdators.length; i++) {
+            _grantRole(ELECTION_EXECUTOR_ROLE, _roles.cohortUpdators[i]);
         }
 
         _setTargetContracts(_targetContracts);

--- a/src/security-council-mgmt/interfaces/ISecurityCouncilManager.sol
+++ b/src/security-council-mgmt/interfaces/ISecurityCouncilManager.sol
@@ -8,7 +8,7 @@ enum Cohort {
 
 struct Roles {
     address admin;
-    address[] cohortUpdator;
+    address[] cohortUpdators;
     address memberAdder;
     address memberRemover;
     address memberRotator;

--- a/src/security-council-mgmt/interfaces/ISecurityCouncilManager.sol
+++ b/src/security-council-mgmt/interfaces/ISecurityCouncilManager.sol
@@ -8,7 +8,7 @@ enum Cohort {
 
 struct Roles {
     address admin;
-    address cohortUpdator;
+    address[] cohortUpdator;
     address memberAdder;
     address memberRemover;
     address memberRotator;


### PR DESCRIPTION
Since both governors call `SecurityCouncilManager.executeElectionResult`, we need to set both governors as a cohortUpdator in the initializer.

Alternatively, we could add something like `SecurityCouncilMemberElectionGovernor.executeElectionResult` (callable only by the `SecurityCouncilNomineeElectionGovernor`) that just calls `SecurityCouncilManager.executeElectionResult`. Then we can have the `SecurityCouncilMemberElectionGovernor` as the sole `cohortUpdator` and throw out this PR.