### PR TITLE
update gov chain security councils after round trip (not directly on l2)

### DIFF
--- a/src/security-council-mgmt/L1SecurityCouncilUpdateRouter.sol
+++ b/src/security-council-mgmt/L1SecurityCouncilUpdateRouter.sol
@@ -122,7 +122,7 @@ contract L1SecurityCouncilUpdateRouter is
         _registerSecurityCouncil(_securityCouncilData);
     }
 
-    /// @notice
+    /// @notice remove security council so it's no longer updated / governed
     /// @param index index of council to remove
     function removeSecurityCouncil(uint256 index) external onlyOwner returns (bool) {
         GovernedSecurityCouncil storage lastSecurityCouncil =

--- a/src/security-council-mgmt/interfaces/IL1SecurityCouncilUpdateRouter.sol
+++ b/src/security-council-mgmt/interfaces/IL1SecurityCouncilUpdateRouter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.16;
 
-struct L2ChainToUpdate {
+struct GovernedSecurityCouncil {
     address inbox;
     address securityCouncilUpgradeExecutor;
     uint256 chainID;
@@ -12,13 +12,13 @@ interface IL1SecurityCouncilUpdateRouter {
         address _governanceChainInbox,
         address _l1SecurityCouncilUpgradeExecutor,
         address _l2SecurityCouncilManager,
-        L2ChainToUpdate[] memory _initiall2ChainsToUpdateArr,
+        GovernedSecurityCouncil[] memory _initiall2ChainsToUpdateArr,
         address _owner
     ) external;
     function handleUpdateMembers(
         address[] calldata _membersToAdd,
         address[] calldata _membersToRemove
     ) external payable;
-    function removeL2Chain(uint256 chainID) external returns (bool);
-    function registerL2Chain(L2ChainToUpdate memory l2ChainToUpdate) external;
+    function removeSecurityCouncil(uint256 index) external returns (bool);
+    function registerSecurityCouncil(GovernedSecurityCouncil memory securityCouncil) external;
 }

--- a/src/security-council-mgmt/interfaces/ISecurityCouncilManager.sol
+++ b/src/security-council-mgmt/interfaces/ISecurityCouncilManager.sol
@@ -14,23 +14,17 @@ struct Roles {
     address memberRotator;
 }
 
-struct TargetContracts {
-    address govChainEmergencySecurityCouncilUpgradeExecutor;
-    address govChainNonEmergencySecurityCouncilUpgradeExecutor;
-    address l1SecurityCouncilUpdateRouter;
-}
-
 interface ISecurityCouncilManager {
     function initialize(
         address[] memory _marchCohort,
         address[] memory _septemberCohort,
         Roles memory _roles,
-        TargetContracts memory _targetContracts
+        address _targetContracts
     ) external;
     function executeElectionResult(address[] memory _newCohort, Cohort _cohort) external;
     function addMemberToCohort(address _newMember, Cohort _cohort) external;
     function removeMember(address _member) external returns (bool);
-    function setTargetContracts(TargetContracts memory _targetContracts) external;
+    function setL1SecurityCouncilUpdateRouter(address _l1SecurityCouncilUpdateRouter) external;
     function getMarchCohort() external view returns (address[] memory);
     function getSeptemberCohort() external view returns (address[] memory);
 }


### PR DESCRIPTION
Previously, the governing chains security councils were updated directly on L2; with this, they are updated after an L2 to L1 confirmation + a retryable (along with the other L2s); the eliminates the week-long discrepancy in members . 

Note that before, each security council the L1SecurityCouncilUpdateRouter had to track mapped to one unique chain; that's no longer the case (since Arb One has both the 9 of 12 and 7 of 12 councils), hence the semantic changes (from "l2 chains" to "security councils")