### PR TITLE
miscellaneous council governor improvements

### DIFF
--- a/src/security-council-mgmt/governors/SecurityCouncilMemberElectionGovernor.sol
+++ b/src/security-council-mgmt/governors/SecurityCouncilMemberElectionGovernor.sol
@@ -1,17 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.16;
 
-import "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorSettingsUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorVotesUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-
-import "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
-
-import "./modules/ArbitrumGovernorVotesQuorumFractionUpgradeable.sol";
 import "./modules/SecurityCouncilMemberElectionGovernorCountingUpgradeable.sol";
 import "./SecurityCouncilNomineeElectionGovernor.sol";
-
-import "../interfaces/ISecurityCouncilManager.sol";
 
 // this contract assumes that any active or successful proposal corresponds to the last NomineeElectionGovernor election
 // we may want to override state() such that a successful proposal expires if it isn't executed after some time

--- a/src/security-council-mgmt/governors/SecurityCouncilNomineeElectionGovernor.sol
+++ b/src/security-council-mgmt/governors/SecurityCouncilNomineeElectionGovernor.sol
@@ -292,6 +292,11 @@ contract SecurityCouncilNomineeElectionGovernor is
     /// @dev    Can be called only while a proposal is active (in voting phase)
     ///         A contender cannot be a member of the opposite cohort.
     function addContender(uint256 proposalId) external {
+        require(
+            !contenders[proposalId][msg.sender],
+            "SecurityCouncilNomineeElectionGovernor: Account is already a contender"
+        );
+
         ProposalState state = state(proposalId);
         require(
             state == ProposalState.Active,

--- a/src/security-council-mgmt/governors/SecurityCouncilNomineeElectionGovernor.sol
+++ b/src/security-council-mgmt/governors/SecurityCouncilNomineeElectionGovernor.sol
@@ -2,12 +2,7 @@
 pragma solidity 0.8.16;
 
 import "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorSettingsUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorVotesUpgradeable.sol";
-import
-    "@openzeppelin/contracts-upgradeable/governance/extensions/GovernorPreventLateQuorumUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-
-import "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
 
 import "lib/solady/src/utils/DateTimeLib.sol";
 

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilMemberElectionGovernorCountingUpgradeable.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilMemberElectionGovernorCountingUpgradeable.sol
@@ -220,6 +220,8 @@ abstract contract SecurityCouncilMemberElectionGovernorCountingUpgradeable is
         uint256 availableVotes,
         bytes memory params
     ) internal virtual override {
+        require(params.length > 0, "SecurityCouncilMemberElectionGovernorCountingUpgradeable: Must cast vote with params");
+
         (address possibleNominee, uint256 votes) = abi.decode(params, (address, uint256));
 
         require(

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilMemberElectionGovernorCountingUpgradeable.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilMemberElectionGovernorCountingUpgradeable.sol
@@ -138,12 +138,20 @@ abstract contract SecurityCouncilMemberElectionGovernorCountingUpgradeable is
     mapping(uint256 => mapping(address => uint256)) private _votesUsed;
 
     // would this be more useful if reason was included?
+    /// @notice Emitted when a vote is cast for a nominee
+    /// @param voter The account that is casting the vote
+    /// @param proposalId The id of the proposal
+    /// @param nominee The nominee that is receiving the vote
+    /// @param votes The amount of votes that were just cast for the nominee
+    /// @param totalUsedVotes The total amount of votes the voter has used for this proposal
+    /// @param totalUsableVotes The total amount of votes the voter has available for this proposal
     event VoteCastForNominee(
         address indexed voter,
         uint256 indexed proposalId,
         address indexed nominee,
         uint256 votes,
-        uint256 weight
+        uint256 totalUsedVotes,
+        uint256 totalUsableVotes
     );
 
     /// @param maxNominees The maximum number of nominees to track
@@ -231,7 +239,14 @@ abstract contract SecurityCouncilMemberElectionGovernorCountingUpgradeable is
         uint256 weight = votesToWeight(proposalId, block.number, votes);
         _increaseNomineeWeight(proposalId, possibleNominee, weight);
 
-        emit VoteCastForNominee(account, proposalId, possibleNominee, votes, weight);
+        emit VoteCastForNominee({
+            voter: account,
+            proposalId: proposalId,
+            nominee: possibleNominee,
+            votes: votes,
+            totalUsedVotes: prevVotesUsed + votes,
+            totalUsableVotes: availableVotes
+        });
     }
 
     function fullWeightVotingDeadline(uint256 proposalId) public view returns (uint256) {

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilMemberElectionGovernorCountingUpgradeable.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilMemberElectionGovernorCountingUpgradeable.sol
@@ -144,14 +144,14 @@ abstract contract SecurityCouncilMemberElectionGovernorCountingUpgradeable is
     /// @param nominee The nominee that is receiving the vote
     /// @param votes The amount of votes that were just cast for the nominee
     /// @param totalUsedVotes The total amount of votes the voter has used for this proposal
-    /// @param totalUsableVotes The total amount of votes the voter has available for this proposal
+    /// @param usableVotes The total amount of votes the voter has available for this proposal
     event VoteCastForNominee(
         address indexed voter,
         uint256 indexed proposalId,
         address indexed nominee,
         uint256 votes,
         uint256 totalUsedVotes,
-        uint256 totalUsableVotes
+        uint256 usableVotes
     );
 
     /// @param maxNominees The maximum number of nominees to track
@@ -220,7 +220,7 @@ abstract contract SecurityCouncilMemberElectionGovernorCountingUpgradeable is
         uint256 availableVotes,
         bytes memory params
     ) internal virtual override {
-        require(params.length > 0, "SecurityCouncilMemberElectionGovernorCountingUpgradeable: Must cast vote with params");
+        require(params.length == 64, "SecurityCouncilMemberElectionGovernorCountingUpgradeable: Must cast vote with abi encoded (nominee, votes)");
 
         (address possibleNominee, uint256 votes) = abi.decode(params, (address, uint256));
 
@@ -247,7 +247,7 @@ abstract contract SecurityCouncilMemberElectionGovernorCountingUpgradeable is
             nominee: possibleNominee,
             votes: votes,
             totalUsedVotes: prevVotesUsed + votes,
-            totalUsableVotes: availableVotes
+            usableVotes: availableVotes
         });
     }
 

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
@@ -79,12 +79,12 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
     }
 
     /// @dev This function is responsible for counting votes when they are cast.
-    ///      If this vote pushes the candidate over the line, then the candidate is added to the nominees
+    ///      If this vote pushes the contender over the line, then the contender is added to the nominees
     ///      and only the necessary amount of votes will be deducted from the voter.
     /// @param proposalId the id of the proposal
     /// @param account the account that is casting the vote
     /// @param weight the amount of vote that account held at time of snapshot
-    /// @param params abi encoded (candidate, votes) where votes is the amount of votes the account is using for this candidate
+    /// @param params abi encoded (contender, votes) where votes is the amount of votes the account is using for this contender
     function _countVote(
         uint256 proposalId,
         address account,
@@ -92,17 +92,17 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
         uint256 weight,
         bytes memory params
     ) internal virtual override {
-        // let's say params is (address candidate, uint256 votes)
-        (address candidate, uint256 votes) = abi.decode(params, (address, uint256));
+        // let's say params is (address contender, uint256 votes)
+        (address contender, uint256 votes) = abi.decode(params, (address, uint256));
 
         require(
-            _isContender(proposalId, candidate),
-            "SecurityCouncilNomineeElectionGovernorCountingUpgradeable: Candidate is not eligible"
+            _isContender(proposalId, contender),
+            "SecurityCouncilNomineeElectionGovernorCountingUpgradeable: Contender is not eligible"
         );
 
         require(
-            !isNominee(proposalId, candidate),
-            "SecurityCouncilNomineeElectionGovernorCountingUpgradeable: Candidate already has enough votes"
+            !isNominee(proposalId, contender),
+            "SecurityCouncilNomineeElectionGovernorCountingUpgradeable: Contender already has enough votes"
         );
 
         NomineeElectionState storage election = _elections[proposalId];
@@ -113,41 +113,41 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
             "SecurityCouncilNomineeElectionGovernorCountingUpgradeable: Not enough tokens to cast this vote"
         );
 
-        uint256 prevVotesReceived = election.votesReceived[candidate];
+        uint256 prevVotesReceived = election.votesReceived[contender];
         uint256 votesThreshold = quorum(proposalSnapshot(proposalId));
 
         emit VoteCastForContender({
             proposalId: proposalId,
             voter: account,
-            contender: candidate,
+            contender: contender,
             votes: votes,
             totalUsedVotes: prevVotesUsed + votes,
             totalUsableVotes: weight
         });
 
         if (prevVotesReceived + votes < votesThreshold) {
-            // we didn't push the candidate over the line, so just add the votes
+            // we didn't push the contender over the line, so just add the votes
             election.votesUsed[account] = prevVotesUsed + votes;
-            election.votesReceived[candidate] = prevVotesReceived + votes;
+            election.votesReceived[contender] = prevVotesReceived + votes;
         } else {
-            // we pushed the candidate over the line
-            // we should only give the candidate enough votes to get to the line so that we don't waste votes
+            // we pushed the contender over the line
+            // we should only give the contender enough votes to get to the line so that we don't waste votes
             uint256 votesNeeded = votesThreshold - prevVotesReceived;
 
             election.votesUsed[account] = prevVotesUsed + votesNeeded;
-            election.votesReceived[candidate] = prevVotesReceived + votesNeeded;
+            election.votesReceived[contender] = prevVotesReceived + votesNeeded;
 
-            // push the candidate to the nominees
-            election.nominees.push(candidate);
+            // push the contender to the nominees
+            election.nominees.push(contender);
 
-            emit NewNominee(proposalId, candidate);
+            emit NewNominee(proposalId, contender);
         }
     }
 
-    /// @notice Returns true if the candidate has enough votes to be a nominee
-    function isNominee(uint256 proposalId, address candidate) public view returns (bool) {
+    /// @notice Returns true if the contender has enough votes to be a nominee
+    function isNominee(uint256 proposalId, address contender) public view returns (bool) {
         return
-            _elections[proposalId].votesReceived[candidate] >= quorum(proposalSnapshot(proposalId));
+            _elections[proposalId].votesReceived[contender] >= quorum(proposalSnapshot(proposalId));
     }
 
     /// @notice Returns the number of nominees for a given proposal

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
@@ -61,6 +61,23 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
         return true;
     }
 
+    function _castVote(
+        uint256 proposalId,
+        address account,
+        uint8 support,
+        string memory reason,
+        bytes memory params
+    ) internal virtual override returns (uint256) {
+        require(params.length > 0, "SecurityCouncilNomineeElectionGovernorCountingUpgradeable: Must provide params to cast a vote");
+        return super._castVote(
+            proposalId,
+            account,
+            support,
+            reason,
+            params
+        );
+    }
+
     /// @dev This function is responsible for counting votes when they are cast.
     ///      If this vote pushes the candidate over the line, then the candidate is added to the nominees
     ///      and only the necessary amount of votes will be deducted from the voter.

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
@@ -61,23 +61,6 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
         return true;
     }
 
-    function _castVote(
-        uint256 proposalId,
-        address account,
-        uint8 support,
-        string memory reason,
-        bytes memory params
-    ) internal virtual override returns (uint256) {
-        require(params.length > 0, "SecurityCouncilNomineeElectionGovernorCountingUpgradeable: Must provide params to cast a vote");
-        return super._castVote(
-            proposalId,
-            account,
-            support,
-            reason,
-            params
-        );
-    }
-
     /// @dev This function is responsible for counting votes when they are cast.
     ///      If this vote pushes the contender over the line, then the contender is added to the nominees
     ///      and only the necessary amount of votes will be deducted from the voter.
@@ -92,6 +75,8 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
         uint256 weight,
         bytes memory params
     ) internal virtual override {
+        require(params.length > 0, "SecurityCouncilNomineeElectionGovernorCountingUpgradeable: Must cast vote with params");
+
         // let's say params is (address contender, uint256 votes)
         (address contender, uint256 votes) = abi.decode(params, (address, uint256));
 

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
@@ -75,7 +75,7 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
         uint256 weight,
         bytes memory params
     ) internal virtual override {
-        require(params.length > 0, "SecurityCouncilNomineeElectionGovernorCountingUpgradeable: Must cast vote with params");
+        require(params.length == 64, "SecurityCouncilNomineeElectionGovernorCountingUpgradeable: Must cast vote with abi encoded (contender, votes)");
 
         // let's say params is (address contender, uint256 votes)
         (address contender, uint256 votes) = abi.decode(params, (address, uint256));

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
@@ -22,8 +22,20 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
     mapping(uint256 => NomineeElectionState) private _elections;
 
     // would this be more useful if reason was included?
+    /// @notice Emitted when a vote is cast for a contender
+    /// @param proposalId The id of the proposal
+    /// @param voter The account that is casting the vote
+    /// @param contender The contender that is receiving the vote
+    /// @param votes The amount of votes that were just cast for the contender
+    /// @param totalUsedVotes The total amount of votes the voter has used for this proposal
+    /// @param totalUsableVotes The total amount of votes the voter has available for this proposal
     event VoteCastForContender(
-        uint256 indexed proposalId, address indexed voter, address indexed contender, uint256 votes
+        uint256 indexed proposalId,
+        address indexed voter,
+        address indexed contender,
+        uint256 votes,
+        uint256 totalUsedVotes,
+        uint256 totalUsableVotes
     );
 
     event NewNominee(uint256 indexed proposalId, address indexed nominee);
@@ -87,7 +99,14 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
         uint256 prevVotesReceived = election.votesReceived[candidate];
         uint256 votesThreshold = quorum(proposalSnapshot(proposalId));
 
-        emit VoteCastForContender(proposalId, account, candidate, votes);
+        emit VoteCastForContender({
+            proposalId: proposalId,
+            voter: account,
+            contender: candidate,
+            votes: votes,
+            totalUsedVotes: prevVotesUsed + votes,
+            totalUsableVotes: weight
+        });
 
         if (prevVotesReceived + votes < votesThreshold) {
             // we didn't push the candidate over the line, so just add the votes

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
@@ -28,14 +28,14 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
     /// @param contender The contender that is receiving the vote
     /// @param votes The amount of votes that were just cast for the contender
     /// @param totalUsedVotes The total amount of votes the voter has used for this proposal
-    /// @param totalUsableVotes The total amount of votes the voter has available for this proposal
+    /// @param usableVotes The total amount of votes the voter has available for this proposal
     event VoteCastForContender(
         uint256 indexed proposalId,
         address indexed voter,
         address indexed contender,
         uint256 votes,
         uint256 totalUsedVotes,
-        uint256 totalUsableVotes
+        uint256 usableVotes
     );
 
     event NewNominee(uint256 indexed proposalId, address indexed nominee);
@@ -123,7 +123,7 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
             contender: contender,
             votes: actualVotes,
             totalUsedVotes: prevVotesUsed + actualVotes,
-            totalUsableVotes: weight
+            usableVotes: weight
         });
     }
 

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
@@ -77,7 +77,7 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
     ) internal virtual override {
         require(params.length == 64, "SecurityCouncilNomineeElectionGovernorCountingUpgradeable: Must cast vote with abi encoded (contender, votes)");
 
-        // let's say params is (address contender, uint256 votes)
+        // params is encoded as (address contender, uint256 votes)
         (address contender, uint256 votes) = abi.decode(params, (address, uint256));
 
         require(


### PR DESCRIPTION
* removed some unused imports
* renamed candidate to contender
* account cannot call `addContender` twice
* require params in `_countVote`
* refactor `SecurityCouncilNomineeElectionGovernorCountingUpgradeable._countVote` to simplify and fix incorrect values in event
* add some params to `VoteCastFor*` events