### PR TITLE
More misc governor changes

### DIFF
--- a/src/security-council-mgmt/governors/SecurityCouncilMemberElectionGovernor.sol
+++ b/src/security-council-mgmt/governors/SecurityCouncilMemberElectionGovernor.sol
@@ -67,47 +67,7 @@ contract SecurityCouncilMemberElectionGovernor is
         _;
     }
 
-    /// @notice Allows the owner to make calls from the governor
-    /// @dev    See {L2ArbitrumGovernor-relay}
-    function relay(address target, uint256 value, bytes calldata data)
-        external
-        virtual
-        override
-        onlyOwner
-    {
-        AddressUpgradeable.functionCallWithValue(target, data, value);
-    }
-
-    /// @notice Always reverts.
-    /// @dev    `GovernorUpgradeable` function to create a proposal overridden to just revert.
-    ///         We only want proposals to be created via `proposeFromNomineeElectionGovernor`.
-    function propose(address[] memory, uint256[] memory, bytes[] memory, string memory)
-        public
-        virtual
-        override
-        returns (uint256)
-    {
-        revert(
-            "SecurityCouncilMemberElectionGovernor: Proposing is not allowed, call proposeFromNomineeElectionGovernor instead"
-        );
-    }
-
-    /// @notice Normally "the number of votes required in order for a voter to become a proposer." But in our case it is 0.
-    /// @dev    Since we only want proposals to be created via `proposeFromNomineeElectionGovernor`, we set the proposal threshold to 0.
-    ///         `proposeFromNomineeElectionGovernor` determines the rules for creating a proposal.
-    function proposalThreshold()
-        public
-        pure
-        override(GovernorSettingsUpgradeable, GovernorUpgradeable)
-        returns (uint256)
-    {
-        return 0;
-    }
-
-    /// @notice Quorum is always 0.
-    function quorum(uint256) public pure override returns (uint256) {
-        return 0;
-    }
+    /************** permissioned state mutating functions **************/
 
     /// @notice Creates a new member election proposal from the most recent nominee election.
     function proposeFromNomineeElectionGovernor() external onlyNomineeElectionGovernor {
@@ -127,6 +87,19 @@ contract SecurityCouncilMemberElectionGovernor is
         securityCouncilManager.replaceCohort(_newCohort, _cohort);
     }
 
+    /// @notice Allows the owner to make calls from the governor
+    /// @dev    See {L2ArbitrumGovernor-relay}
+    function relay(address target, uint256 value, bytes calldata data)
+        external
+        virtual
+        override
+        onlyOwner
+    {
+        AddressUpgradeable.functionCallWithValue(target, data, value);
+    }
+
+    /************** internal/private state mutating functions **************/
+
     /// @dev    `GovernorUpgradeable` function to execute a proposal overridden to handle nominee elections.
     ///         We know that _getTopNominees will return a full list of nominees because we checked it in _voteSucceeded.
     ///         Calls `SecurityCouncilManager.replaceCohort` with the list of nominees.
@@ -144,6 +117,25 @@ contract SecurityCouncilMemberElectionGovernor is
         });
     }
 
+    /************** view/pure functions **************/
+
+    /// @notice Normally "the number of votes required in order for a voter to become a proposer." But in our case it is 0.
+    /// @dev    Since we only want proposals to be created via `proposeFromNomineeElectionGovernor`, we set the proposal threshold to 0.
+    ///         `proposeFromNomineeElectionGovernor` determines the rules for creating a proposal.
+    function proposalThreshold()
+        public
+        pure
+        override(GovernorSettingsUpgradeable, GovernorUpgradeable)
+        returns (uint256)
+    {
+        return 0;
+    }
+
+    /// @notice Quorum is always 0.
+    function quorum(uint256) public pure override returns (uint256) {
+        return 0;
+    }
+
     /// @notice Returns the description of a proposal given the nominee election index.
     function nomineeElectionIndexToDescription(uint256 electionIndex)
         public
@@ -155,6 +147,8 @@ contract SecurityCouncilMemberElectionGovernor is
         );
     }
 
+    /************** internal override view/pure functions **************/
+
     /// @dev returns true if the account is a compliant nominee.
     ///      checks the SecurityCouncilNomineeElectionGovernor to see if the account is a compliant nominee of the most recent nominee election
     function _isCompliantNomineeForMostRecentElection(address possibleNominee)
@@ -164,5 +158,21 @@ contract SecurityCouncilMemberElectionGovernor is
         returns (bool)
     {
         return nomineeElectionGovernor.isCompliantNomineeForMostRecentElection(possibleNominee);
+    }
+
+    /************** disabled functions **************/
+
+    /// @notice Always reverts.
+    /// @dev    `GovernorUpgradeable` function to create a proposal overridden to just revert.
+    ///         We only want proposals to be created via `proposeFromNomineeElectionGovernor`.
+    function propose(address[] memory, uint256[] memory, bytes[] memory, string memory)
+        public
+        virtual
+        override
+        returns (uint256)
+    {
+        revert(
+            "SecurityCouncilMemberElectionGovernor: Proposing is not allowed, call proposeFromNomineeElectionGovernor instead"
+        );
     }
 }

--- a/src/security-council-mgmt/governors/SecurityCouncilMemberElectionGovernor.sol
+++ b/src/security-council-mgmt/governors/SecurityCouncilMemberElectionGovernor.sol
@@ -147,7 +147,7 @@ contract SecurityCouncilMemberElectionGovernor is
         );
     }
 
-    /************** internal override view/pure functions **************/
+    /************** internal view/pure functions **************/
 
     /// @dev returns true if the account is a compliant nominee.
     ///      checks the SecurityCouncilNomineeElectionGovernor to see if the account is a compliant nominee of the most recent nominee election

--- a/src/security-council-mgmt/governors/SecurityCouncilNomineeElectionGovernor.sol
+++ b/src/security-council-mgmt/governors/SecurityCouncilNomineeElectionGovernor.sol
@@ -410,6 +410,8 @@ contract SecurityCouncilNomineeElectionGovernor is
         );
     }
 
+    /************** internal override view/pure functions **************/
+
     /// @inheritdoc SecurityCouncilNomineeElectionGovernorCountingUpgradeable
     function _isContender(uint256 proposalId, address possibleContender)
         internal
@@ -421,7 +423,7 @@ contract SecurityCouncilNomineeElectionGovernor is
         return _elections[proposalId].isContender[possibleContender];
     }
 
-    /************** "disabled" functions **************/
+    /************** disabled functions **************/
 
     /// @notice Always reverts.
     /// @dev    `GovernorUpgradeable` function to create a proposal overridden to just revert.

--- a/src/security-council-mgmt/governors/SecurityCouncilNomineeElectionGovernor.sol
+++ b/src/security-council-mgmt/governors/SecurityCouncilNomineeElectionGovernor.sol
@@ -410,7 +410,7 @@ contract SecurityCouncilNomineeElectionGovernor is
         );
     }
 
-    /************** internal override view/pure functions **************/
+    /************** internal view/pure functions **************/
 
     /// @inheritdoc SecurityCouncilNomineeElectionGovernorCountingUpgradeable
     function _isContender(uint256 proposalId, address possibleContender)

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilMemberElectionGovernorCountingUpgradeable.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilMemberElectionGovernorCountingUpgradeable.sol
@@ -60,10 +60,7 @@ abstract contract SecurityCouncilMemberElectionGovernorCountingUpgradeable is
         _fullWeightDuration = initialFullWeightDuration;
     }
 
-    /// @notice Returns the duration of full weight voting (expressed in blocks)
-    function fullWeightDuration() public view returns (uint256) {
-        return _fullWeightDuration;
-    }
+    /************** permissioned state mutating functions **************/
 
     /// @notice Set the full weight duration numerator and total duration denominator
     function setFullWeightDuration(uint256 newFullWeightDuration) public onlyGovernance {
@@ -73,29 +70,7 @@ abstract contract SecurityCouncilMemberElectionGovernorCountingUpgradeable is
         );
     }
 
-    /// @notice Returns the number of votes used by an account for a given proposal
-    function votesUsed(uint256 proposalId, address account) public view returns (uint256) {
-        return _elections[proposalId].votesUsed[account];
-    }
-
-    function COUNTING_MODE() public pure virtual override returns (string memory) {
-        return "TODO: ???";
-    }
-
-    /// @notice Returns true if the account has voted any amount for any nominee in the proposal
-    function hasVoted(uint256 proposalId, address account) public view override returns (bool) {
-        return votesUsed(proposalId, account) > 0;
-    }
-
-    /// @notice Returns true, since there is no minimum quorum
-    function _quorumReached(uint256) internal pure override returns (bool) {
-        return true;
-    }
-
-    /// @notice Returns true if votes have been cast for at least K nominees
-    function _voteSucceeded(uint256 proposalId) internal view override returns (bool) {
-        return _elections[proposalId].nomineesWithVotes.length >= _targetMemberCount;
-    }
+    /************** internal/private state mutating functions **************/
 
     /// @notice Register a vote by some account for a proposal.
     /// @dev    Reverts if the account does not have enough votes.
@@ -160,49 +135,31 @@ abstract contract SecurityCouncilMemberElectionGovernorCountingUpgradeable is
         });
     }
 
+    /************** view/pure functions **************/
+
+    /// @notice Returns the duration of full weight voting (expressed in blocks)
+    function fullWeightDuration() public view returns (uint256) {
+        return _fullWeightDuration;
+    }
+
+    /// @notice Returns the number of votes used by an account for a given proposal
+    function votesUsed(uint256 proposalId, address account) public view returns (uint256) {
+        return _elections[proposalId].votesUsed[account];
+    }
+
+    function COUNTING_MODE() public pure virtual override returns (string memory) {
+        return "TODO: ???";
+    }
+
+    /// @notice Returns true if the account has voted any amount for any nominee in the proposal
+    function hasVoted(uint256 proposalId, address account) public view override returns (bool) {
+        return votesUsed(proposalId, account) > 0;
+    }
+
     function fullWeightVotingDeadline(uint256 proposalId) public view returns (uint256) {
         uint256 startBlock = proposalSnapshot(proposalId);
 
         return startBlock + _fullWeightDuration;
-    }
-
-    /// @notice Returns the weight of a vote for a given proposal, block number, and number of votes.
-    /// @dev    Uses a piecewise linear function to determine the weight of a vote.
-    function votesToWeight(uint256 proposalId, uint256 blockNumber, uint256 votes)
-        public
-        view
-        returns (uint256)
-    {
-        // Votes cast before T+14 days will have 100% weight.
-        // Votes cast between T+14 days and T+28 days will have weight based on the time of casting,
-        // decreasing linearly with time, with 100% weight at T+14 days, decreasing linearly to 0% weight at T+28 days.
-
-        // 7 days full weight, 14 days decreasing weight
-
-        // do i have an off-by-one in here?
-
-        uint256 endBlock = proposalDeadline(proposalId);
-        uint256 startBlock = proposalSnapshot(proposalId);
-
-        if (blockNumber <= startBlock || blockNumber > endBlock) {
-            return 0;
-        }
-
-        uint256 fullWeightVotingDeadline_ = fullWeightVotingDeadline(proposalId);
-
-        if (blockNumber <= fullWeightVotingDeadline_) {
-            return votes;
-        }
-
-        // slope denominator
-        uint256 decreasingWeightDuration = endBlock - fullWeightVotingDeadline_;
-
-        // slope numerator is -votes, slope denominator is decreasingWeightDuration, delta x is blockNumber - fullWeightVotingDeadline_
-        // y intercept is votes
-        uint256 decreaseAmount =
-            WAD * votes * (blockNumber - fullWeightVotingDeadline_) / decreasingWeightDuration / WAD;
-
-        return decreaseAmount >= votes ? 0 : votes - decreaseAmount;
     }
 
     // gas usage is probably a little bit more than (4200 + 1786)n. With 500 that's 2,993,000
@@ -254,6 +211,57 @@ abstract contract SecurityCouncilMemberElectionGovernorCountingUpgradeable is
         }
 
         return topNomineesAddresses;
+    }
+
+    /// @notice Returns the weight of a vote for a given proposal, block number, and number of votes.
+    /// @dev    Uses a piecewise linear function to determine the weight of a vote.
+    function votesToWeight(uint256 proposalId, uint256 blockNumber, uint256 votes)
+        public
+        view
+        returns (uint256)
+    {
+        // Votes cast before T+14 days will have 100% weight.
+        // Votes cast between T+14 days and T+28 days will have weight based on the time of casting,
+        // decreasing linearly with time, with 100% weight at T+14 days, decreasing linearly to 0% weight at T+28 days.
+
+        // 7 days full weight, 14 days decreasing weight
+
+        // do i have an off-by-one in here?
+
+        uint256 endBlock = proposalDeadline(proposalId);
+        uint256 startBlock = proposalSnapshot(proposalId);
+
+        if (blockNumber <= startBlock || blockNumber > endBlock) {
+            return 0;
+        }
+
+        uint256 fullWeightVotingDeadline_ = fullWeightVotingDeadline(proposalId);
+
+        if (blockNumber <= fullWeightVotingDeadline_) {
+            return votes;
+        }
+
+        // slope denominator
+        uint256 decreasingWeightDuration = endBlock - fullWeightVotingDeadline_;
+
+        // slope numerator is -votes, slope denominator is decreasingWeightDuration, delta x is blockNumber - fullWeightVotingDeadline_
+        // y intercept is votes
+        uint256 decreaseAmount =
+            WAD * votes * (blockNumber - fullWeightVotingDeadline_) / decreasingWeightDuration / WAD;
+
+        return decreaseAmount >= votes ? 0 : votes - decreaseAmount;
+    }
+
+    /************** internal view/pure functions **************/
+
+    /// @notice Returns true, since there is no minimum quorum
+    function _quorumReached(uint256) internal pure override returns (bool) {
+        return true;
+    }
+
+    /// @notice Returns true if votes have been cast for at least K nominees
+    function _voteSucceeded(uint256 proposalId) internal view override returns (bool) {
+        return _elections[proposalId].nomineesWithVotes.length >= _targetMemberCount;
     }
 
     /// @dev Returns true if the possibleNominee is a compliant nominee for the most recent election

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilMemberElectionGovernorCountingUpgradeable.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilMemberElectionGovernorCountingUpgradeable.sol
@@ -40,6 +40,7 @@ abstract contract SecurityCouncilMemberElectionGovernorCountingUpgradeable is
     /// @param weight The weight of the vote that was just cast for the nominee
     /// @param totalUsedVotes The total amount of votes the voter has used for this proposal
     /// @param usableVotes The total amount of votes the voter has available for this proposal
+    /// @param weightReceived The total amount of voting weight the nominee has received for this proposal
     event VoteCastForNominee(
         address indexed voter,
         uint256 indexed proposalId,
@@ -47,7 +48,8 @@ abstract contract SecurityCouncilMemberElectionGovernorCountingUpgradeable is
         uint256 votes,
         uint256 weight,
         uint256 totalUsedVotes,
-        uint256 usableVotes
+        uint256 usableVotes,
+        uint256 weightReceived
     );
 
     /// @param targetMemberCount The maximum number of nominees to track
@@ -131,7 +133,8 @@ abstract contract SecurityCouncilMemberElectionGovernorCountingUpgradeable is
             votes: votes,
             weight: weight,
             totalUsedVotes: prevVotesUsed + votes,
-            usableVotes: availableVotes
+            usableVotes: availableVotes,
+            weightReceived: election.weightReceived[nominee]
         });
     }
 

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
@@ -11,15 +11,14 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
     Initializable,
     GovernorUpgradeable
 {
-    // todo: better name
-    struct NomineeElectionState {
+    /// @param votesUsed The amount of votes the voter has used
+    /// @param votesReceived The amount of votes the contender has received
+    /// @param nominees The list of contenders who've received enough votes to become a nominee
+    struct NomineeElectionCountingInfo {
         mapping(address => uint256) votesUsed;
         mapping(address => uint256) votesReceived;
         address[] nominees;
     }
-
-    // proposalId => NomineeElectionState
-    mapping(uint256 => NomineeElectionState) private _elections;
 
     // would this be more useful if reason was included?
     /// @notice Emitted when a vote is cast for a contender
@@ -40,26 +39,12 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
 
     event NewNominee(uint256 indexed proposalId, address indexed nominee);
 
+    // proposalId => NomineeElectionCountingInfo
+    mapping(uint256 => NomineeElectionCountingInfo) private _elections;
+
     function __SecurityCouncilNomineeElectionGovernorCounting_init() internal onlyInitializing {}
 
-    function COUNTING_MODE() public pure virtual override returns (string memory) {
-        return "TODO: ???";
-    }
-
-    /// @notice returns true if the account has voted any amount for any contender in the proposal
-    function hasVoted(uint256 proposalId, address account) public view override returns (bool) {
-        return _elections[proposalId].votesUsed[account] > 0;
-    }
-
-    /// @dev there is no minimum quorum for nominations, so we just return true
-    function _quorumReached(uint256) internal pure override returns (bool) {
-        return true;
-    }
-
-    /// @dev the vote always succeeds, so we just return true
-    function _voteSucceeded(uint256) internal pure override returns (bool) {
-        return true;
-    }
+    /************** internal/private state mutating functions **************/
 
     /// @dev This function is responsible for counting votes when they are cast.
     ///      If this vote pushes the contender over the line, then the contender is added to the nominees
@@ -93,7 +78,7 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
             "SecurityCouncilNomineeElectionGovernorCountingUpgradeable: Contender already has enough votes"
         );
 
-        NomineeElectionState storage election = _elections[proposalId];
+        NomineeElectionCountingInfo storage election = _elections[proposalId];
         uint256 prevVotesUsed = election.votesUsed[account];
 
         require(
@@ -130,6 +115,17 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
         });
     }
 
+    /************** view/pure functions **************/
+
+    function COUNTING_MODE() public pure virtual override returns (string memory) {
+        return "TODO: ???";
+    }
+
+    /// @notice returns true if the account has voted any amount for any contender in the proposal
+    function hasVoted(uint256 proposalId, address account) public view override returns (bool) {
+        return _elections[proposalId].votesUsed[account] > 0;
+    }
+
     /// @notice Returns true if the contender has enough votes to be a nominee
     function isNominee(uint256 proposalId, address contender) public view returns (bool) {
         return
@@ -154,6 +150,18 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
     /// @notice Returns the amount of votes a contender has received for a given proposal
     function votesReceived(uint256 proposalId, address contender) public view returns (uint256) {
         return _elections[proposalId].votesReceived[contender];
+    }
+
+    /************** internal view/pure functions **************/
+
+    /// @dev there is no minimum quorum for nominations, so we just return true
+    function _quorumReached(uint256) internal pure override returns (bool) {
+        return true;
+    }
+
+    /// @dev the vote always succeeds, so we just return true
+    function _voteSucceeded(uint256) internal pure override returns (bool) {
+        return true;
     }
 
     /// @dev Returns true if the account is a contender for the proposal


### PR DESCRIPTION
this pr doesn't really change any fuctionality

* create `SecurityCouncilNomineeElectionGovernor.ElectionInfo` struct
* add `weightReceived` to `VoteCastForNominee`
* reorder functions

function ordering:
* permissionless state mutating functions
* permissioned state mutating functions
* internal/private state mutating functions
* view/pure functions
* internal override view/pure functions
* disabled functions