### PR TITLE
Security council gov getters

### DIFF
--- a/src/security-council-mgmt/governors/SecurityCouncilMemberElectionGovernor.sol
+++ b/src/security-council-mgmt/governors/SecurityCouncilMemberElectionGovernor.sol
@@ -38,7 +38,7 @@ contract SecurityCouncilMemberElectionGovernor is
         IVotesUpgradeable _token,
         address _owner,
         uint256 _votingPeriod,
-        uint256 _targetMemberCount,
+        uint256 _targetMemberCount, // HENRY: TODO: remove this, won't do it now because it messes with factory
         uint256 _fullWeightDuration
     ) public initializer {
         require(

--- a/src/security-council-mgmt/governors/SecurityCouncilMemberElectionGovernor.sol
+++ b/src/security-council-mgmt/governors/SecurityCouncilMemberElectionGovernor.sol
@@ -49,7 +49,6 @@ contract SecurityCouncilMemberElectionGovernor is
         __Governor_init("SecurityCouncilMemberElectionGovernor");
         __GovernorVotes_init(_token);
         __SecurityCouncilMemberElectionGovernorCounting_init({
-            targetMemberCount: _targetMemberCount,
             initialFullWeightDuration: _fullWeightDuration
         });
         __GovernorSettings_init(0, _votingPeriod, 0);
@@ -158,6 +157,11 @@ contract SecurityCouncilMemberElectionGovernor is
         returns (bool)
     {
         return nomineeElectionGovernor.isCompliantNomineeForMostRecentElection(possibleNominee);
+    }
+
+    /// @inheritdoc SecurityCouncilMemberElectionGovernorCountingUpgradeable
+    function _targetMemberCount() internal view override returns (uint256) {
+        return nomineeElectionGovernor.targetNomineeCount();
     }
 
     /************** disabled functions **************/

--- a/src/security-council-mgmt/governors/SecurityCouncilMemberElectionGovernor.sol
+++ b/src/security-council-mgmt/governors/SecurityCouncilMemberElectionGovernor.sol
@@ -146,6 +146,16 @@ contract SecurityCouncilMemberElectionGovernor is
         );
     }
 
+    /// @notice Returns the proposalId for a given `electionIndex`
+    function nomineeElectionIndexToProposalId(uint256 electionIndex) public pure returns (uint256) {
+        return hashProposal(
+            new address[](1),
+            new uint256[](1),
+            new bytes[](1),
+            keccak256(bytes(nomineeElectionIndexToDescription(electionIndex)))
+        );
+    }
+
     /************** internal view/pure functions **************/
 
     /// @dev returns true if the account is a compliant nominee.

--- a/src/security-council-mgmt/governors/SecurityCouncilNomineeElectionGovernor.sol
+++ b/src/security-council-mgmt/governors/SecurityCouncilNomineeElectionGovernor.sol
@@ -51,8 +51,6 @@ contract SecurityCouncilNomineeElectionGovernor is
         uint256 votingPeriod;
     }
 
-    
-
     /// @notice Information about a nominee election
     /// @param isContender Whether the account is a contender
     /// @param isExcluded Whether the account has been excluded by the nomineeVetter
@@ -307,11 +305,23 @@ contract SecurityCouncilNomineeElectionGovernor is
         return isNominee(proposalId, account) && !_elections[proposalId].isExcluded[account];
     }
 
-    /************** internal view/pure functions **************/
+    /// @notice returns true if the nominee has been excluded by the nomineeVetter for the given proposal
+    function isExcluded(uint256 proposalId, address possibleExcluded)
+        public
+        view
+        returns (bool)
+    {
+        return _elections[proposalId].isExcluded[possibleExcluded];
+    }
+
+    /// @notice returns the number of excluded nominees for the given proposal
+    function excludedNomineeCount(uint256 proposalId) public view returns (uint256) {
+        return _elections[proposalId].excludedNomineeCount;
+    }
 
     /// @inheritdoc SecurityCouncilNomineeElectionGovernorCountingUpgradeable
-    function _isContender(uint256 proposalId, address possibleContender)
-        internal
+    function isContender(uint256 proposalId, address possibleContender)
+        public
         view
         virtual
         override

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorCountingUpgradeable.sol
@@ -69,7 +69,7 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
         (address contender, uint256 votes) = abi.decode(params, (address, uint256));
 
         require(
-            _isContender(proposalId, contender),
+            isContender(proposalId, contender),
             "SecurityCouncilNomineeElectionGovernorCountingUpgradeable: Contender is not eligible"
         );
 
@@ -152,6 +152,13 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
         return _elections[proposalId].votesReceived[contender];
     }
 
+    /// @dev Returns true if the account is a contender for the proposal
+    function isContender(uint256 proposalId, address possibleContender)
+        public
+        view
+        virtual
+        returns (bool);
+
     /************** internal view/pure functions **************/
 
     /// @dev there is no minimum quorum for nominations, so we just return true
@@ -163,13 +170,6 @@ abstract contract SecurityCouncilNomineeElectionGovernorCountingUpgradeable is
     function _voteSucceeded(uint256) internal pure override returns (bool) {
         return true;
     }
-
-    /// @dev Returns true if the account is a contender for the proposal
-    function _isContender(uint256 proposalId, address possibleContender)
-        internal
-        view
-        virtual
-        returns (bool);
 
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new


### PR DESCRIPTION
* add some getters and make some private things public
* remove nomineeHasVotes from `SecurityCouncilMemberElectionGovernorCountingUpgradeable.ElectionInfo`
* `SecurityCouncilMemberElectionGovernorCountingUpgradeable._targetMemberCount` calls the nominee governor instead
* `setFullWeightDuration` wasn't actually setting