### PR TITLE
Security council elections housekeeping patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,5 @@ clean     		:; forge clean
 fmt       		:; forge fmt
 gen-network		:; yarn gen:network
 test      		:  test-unit
+sc-election-test:; FOUNDRY_MATCH_PATH='test/security-council-mgmt/**/*.t.sol' make test
 test-integration:; yarn test:integration

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,6 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
+solady/=lib/solady/src/
 
 @arbitrum/token-bridge-contracts/=node_modules/@arbitrum/token-bridge-contracts
 @arbitrum/nitro-contracts/=node_modules/@arbitrum/nitro-contracts/

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilMemberElectionGovernorCountingUpgradeable.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilMemberElectionGovernorCountingUpgradeable.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.16;
 
 import "@openzeppelin/contracts-upgradeable/governance/GovernorUpgradeable.sol";
 
-import "lib/solady/src/utils/LibSort.sol";
+import "solady/utils/LibSort.sol";
 
 /// @title  SecurityCouncilMemberElectionGovernorCountingUpgradeable
 /// @notice Counting module for the SecurityCouncilMemberElectionGovernor.

--- a/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorTiming.sol
+++ b/src/security-council-mgmt/governors/modules/SecurityCouncilNomineeElectionGovernorTiming.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.16;
 import "../../interfaces/ISecurityCouncilManager.sol";
 
 import "@openzeppelin/contracts-upgradeable/governance/GovernorUpgradeable.sol";
-import "lib/solady/src/utils/DateTimeLib.sol";
+import "solady/utils/DateTimeLib.sol";
 import "../../Common.sol";
 
 /// @title SecurityCouncilNomineeElectionGovernorTiming


### PR DESCRIPTION
Adds a command to the makefile that only runs the Security Council election tests specifically
Updates solady dependency to be referenced through the declaration in `remapping.txt`