### PR TITLE
explicit nonce tracking in deploy script

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -18,7 +18,7 @@ const solidityProfiles = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 1900
+        runs: 1500
       },
     }
   }

--- a/scripts/security-council-mgmt-deployment/deployDummyElectionsContracts.ts
+++ b/scripts/security-council-mgmt-deployment/deployDummyElectionsContracts.ts
@@ -88,7 +88,7 @@ async function deployToken(signer: Wallet) {
   await proxy.deployTransaction.wait();
 
   const token = L2ArbitrumToken__factory.connect(proxy.address, signer);
-  await token.initialize(zxDead, ethers.utils.parseEther("10000000000"), signer.address, { nonce: nonce++ });
+  await (await token.initialize(zxDead, ethers.utils.parseEther("10000000000"), signer.address, { nonce: nonce++ })).wait();
 
   return token;
 }


### PR DESCRIPTION
for some reason deploy scripts were giving a nonce too low error. added explicit nonce tracking.

also changed optimizer setting in hardhat config to match foundry.toml