### PR TITLE
update proposal cancelation docs

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -148,7 +148,7 @@ This means that forming a proposal involves working backwards from the target, w
 You can read more about how the path is encoded in the [proposal lifecycle document](./proposal_lifecycle_example.md)
 
 ## Proposal Cancellation 
-Both governor contracts have the affordance to cancel proposals scheduled in the L2 Timelock. The Security Council can likewise cancel proposals [via calling L2ArbitrumGovernor.relay](src/gov-action-contracts/governance/CancelTimelockOperation.sol). Note that although the core-governor Security Council has the affordance to cancel proposals in the L2 timelock via calling `cancel` directly, for clarity and consistency, it should use the aforementioned `relay` method. 
+Both governor contracts have the affordance to cancel proposals scheduled in the L2 Timelock. The Security Council can likewise cancel proposals [via calling L2ArbitrumGovernor.relay](src/gov-action-contracts/governance/CancelTimelockOperation.sol).
 
 ## Future DAO-Governed Chains
 When a [new L2 chain is authorized by the DAO](https://docs.arbitrum.foundation/new-arb-chains), the following steps should be carried out for the new chain to become DAO-governed:


### PR DESCRIPTION
With AIP 6, the 2nd / redundant path is no longer available (passed but not effectuated as of writing)