### PR TITLE
don't use description text to generate l1 timelock hash

### DIFF
--- a/scripts/proposals/AIP6/generateProposalData.ts
+++ b/scripts/proposals/AIP6/generateProposalData.ts
@@ -199,7 +199,7 @@ async function main() {
   const actionAddresses = chainIds.map((chainId) => actions[chainId]);
 
   const proposal = await buildProposal(
-    description,
+    // description,
     provider,
     scmDeployment.upgradeExecRouteBuilder,
     chainIds,

--- a/scripts/proposals/add-dac-keyset/generateProposalData.ts
+++ b/scripts/proposals/add-dac-keyset/generateProposalData.ts
@@ -32,7 +32,7 @@ async function main() {
   const actionAddresses = [addNovaKeysetAction];
 
   const proposal = await buildProposal(
-    description,
+    // description,
     provider,
     scmDeployment.upgradeExecRouteBuilder,
     chainIds,

--- a/scripts/proposals/coreGovProposalInterface.ts
+++ b/scripts/proposals/coreGovProposalInterface.ts
@@ -1,7 +1,7 @@
 export interface CoreGovPropposal {
   actionChainID: number[];
   actionAddress: string[];
-  description: string;
+  description?: string;
   arbSysSendTxToL1Args: {
     l1Timelock: string;
     calldata: string;
@@ -11,7 +11,7 @@ export interface CoreGovPropposal {
 export interface CoreGovProposal {
   actionChainIds: number[];
   actionAddresses: string[];
-  description: string;
+  description?: string;
   arbSysSendTxToL1Args: {
     l1Timelock: string;
     calldata: string;
@@ -21,7 +21,7 @@ export interface CoreGovProposal {
 export interface NonEmergencySCProposal {
   actionChainIds: number[];
   actionAddresses: string[];
-  description: string;
+  description?: string;
   l2TimelockScheduleArgs: {
     target: "0x0000000000000000000000000000000000000064"; // arb sys address
     calldata: string;


### PR DESCRIPTION
Currently, proposal "description" text is used to generate the L1 timelock salt-hash. This is inconvenient as leads to coordination messiness with proposal data generation and proposal submission; there is also no clear update (description text gets posted on chain regardless). There is no restriction or on-chain enforcement to how the l1timelock salt can get generated; this PR instead uses the action address and chain ids.

Note that the proposal monitor fetches the salt from chain data already, and thus does not need any modifications. 