### PR TITLE
add gnosis safe typechains to yarn build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache 2.0",
   "scripts": {
     "audit:ci": "audit-ci --config ./audit-ci.jsonc",
-    "build": "yarn build:governance && yarn build:token-bridge-types",
+    "build": "yarn build:governance && yarn build:token-bridge-types && yarn build:gnosis-safe-types",
     "build:governance": "hardhat compile",
     "build:token-bridge-types": "cd token-bridge-contracts && yarn && yarn build",
     "build:sc-mgmt": "FOUNDRY_PROFILE=sec_council_mgmt hardhat compile",


### PR DESCRIPTION
needed for `yarn tsc` to compile 