### PR TITLE
Remove ownership transfer in ci

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -182,12 +182,6 @@ jobs:
       - name: Proposal tests
         run: yarn test:proposals
 
-      - name: Prepare asset ownership transfer
-        run: yarn prepare:ownership:transfer
-
-      - name: Execute asset ownership transfer
-        run: yarn execute:ownership:transfer
-
       - name: Verify protocol ownership
         run: yarn verify:ownership:transfer
   

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -181,9 +181,6 @@ jobs:
 
       - name: Proposal tests
         run: yarn test:proposals
-
-      - name: Verify protocol ownership
-        run: yarn verify:ownership:transfer
   
   test-integration:
     name: Test integration

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -71,6 +71,8 @@
         // undici proxy autho again - same as GHSA-3787-6prv-h9w3
         "GHSA-m4v8-wqvr-p9f7",
         // undici fetch with integrity action is too lax - again we only use undici in dev so not an issue
-        "GHSA-9qxr-qj54-h672"
+        "GHSA-9qxr-qj54-h672",
+        // memory exhaustion possible in lib/parse, but we only use node in dev so not an issue for us
+        "GHSA-grv7-fg5c-xmjg"
     ]
   }


### PR DESCRIPTION
Removed ownership transfer from the ci since we now have an upgrade executor as owner by default in the testnode