### PR TITLE
fix: propmon - incorrect handling of batches and add timeout retries

### DIFF
--- a/src-ts/proposalMonitorCli.ts
+++ b/src-ts/proposalMonitorCli.ts
@@ -1,5 +1,4 @@
 import { BigNumber, Wallet } from "ethers";
-import { JsonRpcProvider } from "@ethersproject/providers";
 import { ProposalStageStatus, getProvider } from "./proposalStage";
 import { StageFactory, TrackerEventName } from "./proposalPipeline";
 import { SecurityCouncilElectionTracker } from "./securityCouncilElectionTracker";
@@ -16,6 +15,7 @@ import {
   ProposalMonitor,
 } from "./proposalMonitor";
 import axios from "axios";
+import { RetryJsonRpcProvider } from "./retryJsonRpcProvider";
 
 const ETH_KEY = process.env.ETH_KEY || "";
 const ARB_KEY = process.env.ARB_KEY || "";
@@ -207,13 +207,13 @@ const main = async () => {
   if (options.writeMode && !ARB_KEY) throw new Error("env var ARB_KEY required");
   if (options.writeMode && !ETH_KEY) throw new Error("env var ETH_KEY required");
 
-  const l1Provider = new JsonRpcProvider(options.l1RpcUrl);
+  const l1Provider = new RetryJsonRpcProvider(options.l1RpcUrl);
   const l1SignerOrProvider = options.writeMode ? new Wallet(ETH_KEY, l1Provider) : l1Provider;
-  const govChainProvider = new JsonRpcProvider(options.govChainRpcUrl);
+  const govChainProvider = new RetryJsonRpcProvider(options.govChainRpcUrl);
   const govChainSignerOrProvider = options.writeMode
     ? new Wallet(ARB_KEY, govChainProvider)
     : govChainProvider;
-  const novaProvider = new JsonRpcProvider(options.novaRpcUrl);
+  const novaProvider = new RetryJsonRpcProvider(options.novaRpcUrl);
   const novaSignerOrProvider = options.writeMode ? new Wallet(ARB_KEY, novaProvider) : novaProvider;
 
   if (options.writeMode) {

--- a/src-ts/proposalStage.ts
+++ b/src-ts/proposalStage.ts
@@ -375,8 +375,8 @@ export class GovernorQueueStage extends BaseGovernorExecuteStage {
       toBlock: "latest",
       ...callScheduledFilter,
     });
-    if (logs.length !== 1) {
-      throw new ProposalStageError("Log length not 1", this.identifier, this.name);
+    if (logs.length < 1) {
+      throw new ProposalStageError("Log length < 1", this.identifier, this.name);
     }
 
     return await provider!.getTransactionReceipt(logs[0].transactionHash);
@@ -543,8 +543,8 @@ abstract class L2TimelockExecutionStage implements ProposalStage {
       ...callExecutedFilter,
     });
 
-    if (logs.length !== 1) {
-      throw new ProposalStageError(`Logs length not 1: ${logs.length}`, this.identifier, this.name);
+    if (logs.length < 1) {
+      throw new ProposalStageError(`Logs length < 1: ${logs.length}`, this.identifier, this.name);
     }
 
     return await provider!.getTransactionReceipt(logs[0].transactionHash);

--- a/src-ts/retryJsonRpcProvider.ts
+++ b/src-ts/retryJsonRpcProvider.ts
@@ -1,0 +1,46 @@
+import { JsonRpcProvider, Networkish } from "@ethersproject/providers";
+import { ConnectionInfo } from "ethers/lib/utils";
+
+export type RetryJsonRpcProviderParams = {
+  maxRetries: number
+  retryInterval: number
+  exponentialBase: number
+}
+
+export class RetryJsonRpcProvider extends JsonRpcProvider {
+  constructor(
+    url?: ConnectionInfo | string, 
+    network?: Networkish, 
+    public readonly retryParams: RetryJsonRpcProviderParams = {maxRetries: 10, retryInterval: 1000, exponentialBase: 2}
+  ) {
+    super(url, network);
+  }
+
+  private async _wait(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  async send(method: string, params: any[]): Promise<any> {
+    let retries = 0
+    while (true) {
+      try {
+        return await super.send(method, params);
+      }
+      catch (e: any) {
+        if (e.code !== 'TIMEOUT') throw e;
+
+        if (retries >= this.retryParams.maxRetries) {
+          throw new Error(`Max retries exceeded for ${method}`);
+        }
+        
+        const waitDuration = this.retryParams.retryInterval * Math.pow(this.retryParams.exponentialBase, retries);
+
+        console.warn(`${method} retry #${retries+1} in ${waitDuration}ms`);
+
+        await this._wait(waitDuration);
+
+        retries++;
+      }
+    }
+  }
+}


### PR DESCRIPTION
The propmon was erroring on > 1 `CallScheduled` and `CallExecuted` timelock events, but the timelocks emit more than one for batches

I was getting timeouts from the arb1 rpc on 2 different home internet connections, which would crash the script. I added a new `RetryJsonRpcProvider` class that overrides `send` to add retries

