### PR TITLE
fix: ci issue due to new geth behavior

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -129,6 +129,8 @@ jobs:
         with:
           submodules: recursive
       - uses: OffchainLabs/actions/run-nitro-test-node@main
+        with:
+          no-token-bridge: true
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -190,6 +192,8 @@ jobs:
         with:
           submodules: recursive
       - uses: OffchainLabs/actions/run-nitro-test-node@main
+        with:
+          no-token-bridge: true
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -81,7 +81,10 @@
         // ECDSA missing leading bit r and s check - only used in dev
         "GHSA-977x-g7h5-7qgw",
         // EDDSA missing sig length check - package only used in dev
-        "GHSA-f7q4-pwc6-w24p"
-
+        "GHSA-f7q4-pwc6-w24p",
+        // Server-Side Request Forgery in axios
+        "GHSA-8hc4-vh64-cxmj",
+        // Regular Expression Denial of Service (ReDoS) in micromatch
+        "GHSA-952p-6rrq-rcjv"
     ]
   }

--- a/scripts/governanceDeployer.ts
+++ b/scripts/governanceDeployer.ts
@@ -725,9 +725,9 @@ async function registerTokenOnArbOne(
   const arbGatewaySubmissionFee = (
     await arbInbox.callStatic.calculateRetryableSubmissionFee(
       ethers.utils.hexDataLength(arbGatewayRegistrationData),
-      0
+      (await ethDeployer.getGasPrice()).mul(2)
     )
-  ).mul(10); // 10x this to address potential gas spike due to deployment
+  );
   const valueForArbGateway = arbGatewaySubmissionFee.add(arbMaxGas.mul(arbGasPrice));
 
   const extraValue = 1000;
@@ -772,9 +772,9 @@ async function registerTokenOnArbOne(
   const arbRouterSubmissionFee = (
     await arbInbox.callStatic.calculateRetryableSubmissionFee(
       ethers.utils.hexDataLength(arbRouterRegistrationData),
-      0
+      (await ethDeployer.getGasPrice()).mul(2)
     )
-  ).mul(2);
+  );
   const valueForArbRouter = arbRouterSubmissionFee.add(arbMaxGas.mul(arbGasPrice));
 
   if (!deployedContracts.registerTokenArbOne2) {
@@ -834,9 +834,9 @@ async function registerTokenOnNova(
   const novaGatewaySubmissionFee = (
     await novaInbox.callStatic.calculateRetryableSubmissionFee(
       ethers.utils.hexDataLength(novaGatewayRegistrationData),
-      0
+      (await ethDeployer.getGasPrice()).mul(2)
     )
-  ).mul(2);
+  );
   const valueForNovaGateway = novaGatewaySubmissionFee.add(maxGas.mul(novaGasPrice));
 
   // calcs for novaRouter
@@ -847,9 +847,9 @@ async function registerTokenOnNova(
   const novaRouterSubmissionFee = (
     await novaInbox.callStatic.calculateRetryableSubmissionFee(
       ethers.utils.hexDataLength(novaRouterRegistrationData),
-      0
+      (await ethDeployer.getGasPrice()).mul(2)
     )
-  ).mul(2);
+  );
   const valueForNovaRouter = novaRouterSubmissionFee.add(maxGas.mul(novaGasPrice));
 
   // do the registration

--- a/scripts/governanceDeployer.ts
+++ b/scripts/governanceDeployer.ts
@@ -725,9 +725,9 @@ async function registerTokenOnArbOne(
   const arbGatewaySubmissionFee = (
     await arbInbox.callStatic.calculateRetryableSubmissionFee(
       ethers.utils.hexDataLength(arbGatewayRegistrationData),
-      (await ethDeployer.getGasPrice()).mul(2)
+      await ethDeployer.getGasPrice()
     )
-  );
+  ).mul(2)
   const valueForArbGateway = arbGatewaySubmissionFee.add(arbMaxGas.mul(arbGasPrice));
 
   const extraValue = 1000;
@@ -772,9 +772,9 @@ async function registerTokenOnArbOne(
   const arbRouterSubmissionFee = (
     await arbInbox.callStatic.calculateRetryableSubmissionFee(
       ethers.utils.hexDataLength(arbRouterRegistrationData),
-      (await ethDeployer.getGasPrice()).mul(2)
+      await ethDeployer.getGasPrice()
     )
-  );
+  ).mul(2)
   const valueForArbRouter = arbRouterSubmissionFee.add(arbMaxGas.mul(arbGasPrice));
 
   if (!deployedContracts.registerTokenArbOne2) {
@@ -834,9 +834,9 @@ async function registerTokenOnNova(
   const novaGatewaySubmissionFee = (
     await novaInbox.callStatic.calculateRetryableSubmissionFee(
       ethers.utils.hexDataLength(novaGatewayRegistrationData),
-      (await ethDeployer.getGasPrice()).mul(2)
+      await ethDeployer.getGasPrice()
     )
-  );
+  ).mul(2)
   const valueForNovaGateway = novaGatewaySubmissionFee.add(maxGas.mul(novaGasPrice));
 
   // calcs for novaRouter
@@ -847,9 +847,9 @@ async function registerTokenOnNova(
   const novaRouterSubmissionFee = (
     await novaInbox.callStatic.calculateRetryableSubmissionFee(
       ethers.utils.hexDataLength(novaRouterRegistrationData),
-      (await ethDeployer.getGasPrice()).mul(2)
+      await ethDeployer.getGasPrice()
     )
-  );
+  ).mul(2)
   const valueForNovaRouter = novaRouterSubmissionFee.add(maxGas.mul(novaGasPrice));
 
   // do the registration

--- a/scripts/governanceDeployer.ts
+++ b/scripts/governanceDeployer.ts
@@ -727,7 +727,7 @@ async function registerTokenOnArbOne(
       ethers.utils.hexDataLength(arbGatewayRegistrationData),
       await ethDeployer.getGasPrice()
     )
-  ).mul(2)
+  ).mul(2);
   const valueForArbGateway = arbGatewaySubmissionFee.add(arbMaxGas.mul(arbGasPrice));
 
   const extraValue = 1000;
@@ -774,7 +774,7 @@ async function registerTokenOnArbOne(
       ethers.utils.hexDataLength(arbRouterRegistrationData),
       await ethDeployer.getGasPrice()
     )
-  ).mul(2)
+  ).mul(2);
   const valueForArbRouter = arbRouterSubmissionFee.add(arbMaxGas.mul(arbGasPrice));
 
   if (!deployedContracts.registerTokenArbOne2) {
@@ -836,7 +836,7 @@ async function registerTokenOnNova(
       ethers.utils.hexDataLength(novaGatewayRegistrationData),
       await ethDeployer.getGasPrice()
     )
-  ).mul(2)
+  ).mul(2);
   const valueForNovaGateway = novaGatewaySubmissionFee.add(maxGas.mul(novaGasPrice));
 
   // calcs for novaRouter
@@ -849,7 +849,7 @@ async function registerTokenOnNova(
       ethers.utils.hexDataLength(novaRouterRegistrationData),
       await ethDeployer.getGasPrice()
     )
-  ).mul(2)
+  ).mul(2);
   const valueForNovaRouter = novaRouterSubmissionFee.add(maxGas.mul(novaGasPrice));
 
   // do the registration

--- a/scripts/governanceDeployer.ts
+++ b/scripts/governanceDeployer.ts
@@ -727,7 +727,7 @@ async function registerTokenOnArbOne(
       ethers.utils.hexDataLength(arbGatewayRegistrationData),
       0
     )
-  ).mul(2);
+  ).mul(10); // 10x this to address potential gas spike due to deployment
   const valueForArbGateway = arbGatewaySubmissionFee.add(arbMaxGas.mul(arbGasPrice));
 
   const extraValue = 1000;

--- a/src-ts/proposalStage.ts
+++ b/src-ts/proposalStage.ts
@@ -1058,7 +1058,7 @@ abstract class L1TimelockExecutionStage {
       const inbox = Inbox__factory.connect(inboxAddress, timelock.provider!);
       const submissionFee = await inbox.callStatic.calculateRetryableSubmissionFee(
         hexDataLength(innerData),
-        0
+        await inbox.provider!.getGasPrice()
       );
 
       // enough value to create a retryable ticket = submission fee + gas

--- a/test-ts/integration.ts
+++ b/test-ts/integration.ts
@@ -719,7 +719,7 @@ const execL1Component = async (
     const inbox = Inbox__factory.connect(l2Network.ethBridge.inbox, l1Deployer.provider!);
     const submissionFee = await inbox.callStatic.calculateRetryableSubmissionFee(
       propFormNonEmpty.l1Gov.retryableDataLength,
-      0
+      await inbox.provider!.getGasPrice()
     );
     value = submissionFee.mul(2);
   }


### PR DESCRIPTION
Speedup testnode by disabling token bridge deployment there. Also fixes an issue where newer geth default to have basefee=0 when doing a eth_call so we cannot use 0 (expecting block.basefee) when estimating for retryable submission cost. (and testnode recently bumped the geth version)

And whitelist new yarn audit issues.