### PR TITLE
Propmon: retry failing retryables

### DIFF
--- a/src-ts/proposalStage.ts
+++ b/src-ts/proposalStage.ts
@@ -1388,13 +1388,9 @@ export class RetryableExecutionStage implements ProposalStage {
       try {
         await (await this.l1ToL2Message.redeem()).wait();
         break;
-      } catch (e) {
-        const knownPending = JSON.parse(process.env.PENDING_RETRYABLES?.toLowerCase() || "[]");
+      } catch {
         const id = this.l1ToL2Message.retryableCreationId.toLowerCase();
-        if (!knownPending.includes(id)) {
-          throw e
-        }
-        console.log(`Failed to redeem retryable ${id}, retrying in 60s`);
+        console.error(`Failed to redeem retryable ${id}, retrying in 60s`);
         await wait(60_000);
       }
     }


### PR DESCRIPTION
Trying to execute a retryable that cannot be redeemed will crash propmon. ~~We should probably keep this behavior so we are alerted to this.~~

However, some retryables are expected to not be redeemable for some period of time. This PR modifies the behavior of RetryableExecutionStage::execute to keep trying to redeem every minute ~~if the retryable ID is in a whitelist. If the retryable is not in the list, propmon will crash as usual.~~

~~eg, add this to .env~~

~~PENDING_RETRYABLES='["0x42cdcf30aa6de466277d44efa3fef5c0ebd0ca79b2585cb8b79625451dfc4a73","0xbfac911b67e7f79a69e0e9afc329573e3b7a017c1d31e7b368f59cdcab25110a"]'~~