### PR TITLE
fix: propmon redeemed ticket race condition

### DIFF
--- a/src-ts/proposalStage.ts
+++ b/src-ts/proposalStage.ts
@@ -1395,7 +1395,7 @@ export class RetryableExecutionStage implements ProposalStage {
         }
         const id = this.l1ToL2Message.retryableCreationId.toLowerCase();
         console.error(`Failed to redeem retryable ${id}, retrying in 60s`);
-        await wait(60_000);
+        await wait(5_000);
       }
     }
   }

--- a/src-ts/proposalStage.ts
+++ b/src-ts/proposalStage.ts
@@ -40,6 +40,7 @@ import {
 import { hasTimelock, hasVettingPeriod, getL1BlockNumberFromL2, wait } from "./utils";
 import { CallScheduledEvent } from "../typechain-types/src/ArbitrumTimelock";
 import { GnosisSafeL2__factory } from "../types/ethers-contracts/factories/GnosisSafeL2__factory";
+import { ArbSdkError } from "@arbitrum/sdk/dist/lib/dataEntities/errors";
 
 type Provider = providers.Provider;
 
@@ -1385,17 +1386,13 @@ export class RetryableExecutionStage implements ProposalStage {
     }
 
     while (true) {
-      const status = await this.l1ToL2Message.status();
-      if (status === L1ToL2MessageStatus.REDEEMED) {
-        break;
-      } else if (status === L1ToL2MessageStatus.EXPIRED) {
-        const id = this.l1ToL2Message.retryableCreationId.toLowerCase();
-        throw new ProposalStageError(`Retryable ticket expired ${id}`, this.identifier, this.name);
-      }
       try {
         await (await this.l1ToL2Message.redeem()).wait();
         break;
-      } catch {
+      } catch (e) {
+        if (e instanceof ArbSdkError && e.message.includes("Message status: REDEEMED")) {
+          break;
+        }
         const id = this.l1ToL2Message.retryableCreationId.toLowerCase();
         console.error(`Failed to redeem retryable ${id}, retrying in 60s`);
         await wait(60_000);

--- a/src-ts/proposalStage.ts
+++ b/src-ts/proposalStage.ts
@@ -1385,6 +1385,13 @@ export class RetryableExecutionStage implements ProposalStage {
     }
 
     while (true) {
+      const status = await this.l1ToL2Message.status();
+      if (status === L1ToL2MessageStatus.REDEEMED) {
+        break;
+      } else if (status === L1ToL2MessageStatus.EXPIRED) {
+        const id = this.l1ToL2Message.retryableCreationId.toLowerCase();
+        throw new ProposalStageError(`Retryable ticket expired ${id}`, this.identifier, this.name);
+      }
       try {
         await (await this.l1ToL2Message.redeem()).wait();
         break;

--- a/src-ts/proposalStage.ts
+++ b/src-ts/proposalStage.ts
@@ -1394,7 +1394,7 @@ export class RetryableExecutionStage implements ProposalStage {
           break;
         }
         const id = this.l1ToL2Message.retryableCreationId.toLowerCase();
-        console.error(`Failed to redeem retryable ${id}, retrying in 60s`);
+        console.error(`Failed to redeem retryable ${id}, retrying in 5s`);
         await wait(5_000);
       }
     }


### PR DESCRIPTION
Regression of #314, it is possible the redeem call reverted due to the ticket is already redeemed. Fix by checking the status before redeem.